### PR TITLE
add extra query functionality

### DIFF
--- a/query_scivision_catalog.ipynb
+++ b/query_scivision_catalog.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1e078eb7",
+   "id": "80bdabba",
    "metadata": {},
    "source": [
     "## test notebook for querying scivision catalogs"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f87373cf",
+   "id": "b707f974",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "b8db5021",
+   "id": "3ce05a93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8a328688",
+   "id": "0a278e0b",
    "metadata": {},
    "outputs": [
     {
@@ -70,8 +70,80 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
+   "id": "ef62ac35",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['task',\n",
+       " 'domain',\n",
+       " 'datasource',\n",
+       " 'model',\n",
+       " 'github_branch',\n",
+       " 'language',\n",
+       " 'institution',\n",
+       " 'tags']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "catalog.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['segmentation',\n",
+       " 'feature-extraction',\n",
+       " 'object-detection',\n",
+       " 'classification',\n",
+       " 'measurement']"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "catalog.values(\"task\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "query() missing 1 required positional argument: 'query'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/cw/g03qkb894c19n6qsvnpyfjkr0000gn/T/ipykernel_42332/2715441273.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mcatalog\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mquery\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m: query() missing 1 required positional argument: 'query'"
+     ]
+    }
+   ],
+   "source": [
+    "catalog.query()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "id": "07584373",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -79,9 +151,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:scivision]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-scivision-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/scivision/catalog/__init__.py
+++ b/scivision/catalog/__init__.py
@@ -1,1 +1,1 @@
-from .catalog import query
+from .catalog import keys, query, values

--- a/scivision/catalog/catalog.py
+++ b/scivision/catalog/catalog.py
@@ -36,7 +36,6 @@ class BaseCatalog(abc.ABC):
     def keys(self) -> List[str]:
         raise NotImplementedError
 
-    @property
     @abc.abstractmethod
     def values(self, key: str) -> List[str]:
         raise NotImplementedError


### PR DESCRIPTION
This PR adds:
* return an empty list for an empty query
* `catalog.keys()` the valid (searchable) keys from the database
* `catalog.values(key)` - the unique values in the database for a valid `key`
* updated example notebook