### PR TITLE
Add load_dataset function

### DIFF
--- a/.github/workflows/scivision.yml
+++ b/.github/workflows/scivision.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
 #     - uses: psf/black@stable
 #       with:
 #         options: "--check --verbose --line-length=79"

--- a/scivision/io/__init__.py
+++ b/scivision/io/__init__.py
@@ -1,1 +1,1 @@
-from .reader import load_pretrained_model
+from .reader import load_pretrained_model, load_dataset

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -7,6 +7,7 @@ import yaml
 import intake
 import intake_xarray
 # import xarray as xr
+import tempfile
 import requests
 import yaml
 from intake.catalog.local import YAMLFileCatalog
@@ -92,7 +93,6 @@ def load_pretrained_model(
 
 def load_dataset(
     #TODO allow to load a local yaml OR GitHub yaml
-    #TODO use saving the yaml to a local tmp file
     path: os.PathLike,
     branch: str = "main"
 ) -> intake.catalog.local.YAMLFileCatalog:
@@ -103,6 +103,7 @@ def load_dataset(
     config = _parse_url(path, branch=branch)
     r = requests.get(config)
     yaml_config = yaml.load(r.content, Loader=yaml.Loader)
-    with open('scivision.yaml', 'w') as file:
+    tempdir = tempfile.mkdtemp()
+    with open(tempdir + '/scivision.yml', 'w') as file:
         yaml.dump(yaml_config, file)
-    return intake.open_catalog('scivision.yaml')
+    return intake.open_catalog(tempdir + '/scivision.yml')

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -115,7 +115,5 @@ def load_dataset(
         
     # This will throw an error if the path does not exist
     file = fsspec.open(path)
-    with file as config_file:
-        stream = config_file.read()
-        config = yaml.safe_load(stream)
+
     return intake.open_catalog(path)

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -112,4 +112,10 @@ def load_dataset(
     # if not, assume it is a repo containing "scivision.yml"
     if not path.endswith((".yml", ".yaml",)):
         path = path + "scivision.yml"
+        
+    # This will throw an error if the path does not exist
+    file = fsspec.open(path)
+    with file as config_file:
+        stream = config_file.read()
+        config = yaml.safe_load(stream)
     return intake.open_catalog(path)

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -52,7 +52,7 @@ def _parse_config(path: os.PathLike, branch: str = "main") -> dict:
         config = yaml.safe_load(stream)
 
     # make sure we at least have an input to the function
-    # assert "X" in config["prediction_fn"]["args"].keys()
+    assert "X" in config["prediction_fn"]["args"].keys()
 
     return config
 

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -29,7 +29,7 @@ def _parse_url(path: os.PathLike, branch: str = "main"):
     return parsed.geturl()
 
 
-def _parse_config(path: os.PathLike, branch: str = "main", model_config=True) -> dict:
+def _parse_config(path: os.PathLike, branch: str = "main", model_config: bool = True) -> dict:
     """Parse the scivision.yml file from a GitHub repository.
     Will also accept differently named yaml if a full path provided or a local file.
     """

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -99,11 +99,10 @@ def load_dataset(
     """Load a dataset from the path specified in scivision.yml."""
     # parse the config file
     # path = path + 'scivision.yml' #TODO: change _parse_config
+    # check whether scivision.yml or scivision.yaml exists and throw an error if not
     config = _parse_url(path, branch=branch)
     r = requests.get(config)
     yaml_config = yaml.load(r.content, Loader=yaml.Loader)
-    yamlcatalog = YAMLFileCatalog(path='', autoreload=False)
-    yamlcatalog.from_dict(yaml_config)
-    return yamlcatalog
-    # print(config)
-    # return intake.open_catalog(r.content)
+    with open('scivision.yaml', 'w') as file:
+        yaml.dump(yaml_config, file)
+    return intake.open_catalog('scivision.yaml')

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -26,9 +26,9 @@ def _parse_url(path: os.PathLike, branch: str = "main"):
     new_path = "/".join(split[:2]) + f"/{branch}/" + "/".join(split[2:])
     parsed = parsed._replace(path=new_path)
     return parsed.geturl()
-
-
-def _parse_config(path: os.PathLike, branch: str = "main") -> dict:
+    
+    
+def _parse_path(path: os.PathLike, branch: str = "main") -> dict:
     """Parse the scivision.yml file from a GitHub repository.
     Will also accept differently named yaml if a full path provided or a local file.
     """
@@ -40,8 +40,16 @@ def _parse_config(path: os.PathLike, branch: str = "main") -> dict:
     # if not, assume it is a repo containing "scivision.yml"
     if not path.endswith((".yml", ".yaml",)):
         path = path + "scivision.yml"
+    return path
 
-    # This will throw an error if the path does not exist
+
+def _parse_config(path: os.PathLike, branch: str = "main") -> dict:
+    """Parse the scivision.yml file from a GitHub repository.
+    Will also accept differently named yaml if a full path provided or a local file.
+    """
+    
+    path = _parse_path(path, branch)
+    # fsspec will throw an error if the path does not exist
     file = fsspec.open(path)
     with file as config_file:
         stream = config_file.read()
@@ -105,15 +113,8 @@ def load_dataset(
     intake.catalog.local.YAMLFileCatalog
         The intake catalog object from which an xarray dataset can be created.
     """
-    if _is_url(path):
-        path = _parse_url(path, branch)
-
-    # check that this is a path to a yaml file
-    # if not, assume it is a repo containing "scivision.yml"
-    if not path.endswith((".yml", ".yaml",)):
-        path = path + "scivision.yml"
-        
-    # This will throw an error if the path does not exist
-    file = fsspec.open(path)
-
+    
+    path = _parse_path(path, branch)
+    # fsspec will throw an error if the path does not exist
+    fsspec.open(path)
     return intake.open_catalog(path)

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -47,9 +47,6 @@ def _parse_config(path: os.PathLike, branch: str = "main") -> dict:
         stream = config_file.read()
         config = yaml.safe_load(stream)
 
-    # make sure a model at least has an input to the function
-    assert "X" in config["prediction_fn"]["args"].keys()
-
     return config
 
 
@@ -80,6 +77,9 @@ def load_pretrained_model(
 
     # parse the config file
     config = _parse_config(path, branch=branch)
+    
+    # make sure a model at least has an input to the function
+    assert "X" in config["prediction_fn"]["args"].keys()
 
     # try to install the package if necessary
     install_package(config, allow_install=allow_install)

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -2,14 +2,9 @@ import os
 from urllib.parse import urlparse
 
 import fsspec
-import yaml
-
 import intake
-import intake_xarray
-# import xarray as xr
 import tempfile
 import yaml
-from intake.catalog.local import YAMLFileCatalog
 
 from ..koala import koala
 from .installer import install_package

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -37,8 +37,8 @@ def _parse_url(path: os.PathLike, branch: str = "main"):
 
 
 def _parse_config(path: os.PathLike, branch: str = "main", model_config=True) -> dict:
-    """Parse the scivision.yml file.
-    Will also accept differently named yaml if a full path provided or local file.
+    """Parse the scivision.yml file from a GitHub repository.
+    Will also accept differently named yaml if a full path provided or a local file.
     """
 
     if _is_url(path):
@@ -100,7 +100,20 @@ def load_dataset(
     path: os.PathLike,
     branch: str = "main"
 ) -> intake.catalog.local.YAMLFileCatalog:
-    """Load a dataset from the path specified in scivision.yml."""
+    """Load a pre-trained model.
+
+    Parameters
+    ----------
+    path : PathLike
+        The filename, path or URL of an intake catalog, which links to a dataset.
+    branch : str, default = main
+        Specify the name of a github branch if loading from github.
+
+    Returns
+    -------
+    intake.catalog.local.YAMLFileCatalog
+        The intake catalog object from which an xarray dataset can be created.
+    """
     config = _parse_config(path, branch=branch, model_config=False)
     tempdir = tempfile.mkdtemp()
     with open(tempdir + '/scivision.yml', 'w') as file:

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -101,8 +101,6 @@ def load_dataset(
     branch: str = "main"
 ) -> intake.catalog.local.YAMLFileCatalog:
     """Load a dataset from the path specified in scivision.yml."""
-    # parse the config file
-    # path = path + 'scivision.yml' #TODO: change _parse_config
     config = _parse_config(path, branch=branch, model_config=False)
     tempdir = tempfile.mkdtemp()
     with open(tempdir + '/scivision.yml', 'w') as file:

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -37,14 +37,19 @@ def _parse_url(path: os.PathLike, branch: str = "main"):
 
 
 def _parse_config(path: os.PathLike, branch: str = "main", model_config=True) -> dict:
-    """Parse the `scivision` config file."""
-    # check that this is a path to a yaml file
-    if not path.endswith((".yml", ".yaml",)):
-        raise ValueError(f"Invalid configuration filename: {path}")
+    """Parse the scivision.yml file.
+    Will also accept differently named yaml if a full path provided or local file.
+    """
 
     if _is_url(path):
         path = _parse_url(path, branch)
 
+    # check that this is a path to a yaml file
+    # if not, assume it is a repo containing "scivision.yml"
+    if not path.endswith((".yml", ".yaml",)):
+        path = path + "scivision.yml"
+
+    # This will throw an error if the path does not exist
     file = fsspec.open(path)
     with file as config_file:
         stream = config_file.read()

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -4,6 +4,13 @@ from urllib.parse import urlparse
 import fsspec
 import yaml
 
+import intake
+import intake_xarray
+# import xarray as xr
+import requests
+import yaml
+from intake.catalog.local import YAMLFileCatalog
+
 from ..koala import koala
 from .installer import install_package
 from .wrapper import PretrainedModel
@@ -44,7 +51,7 @@ def _parse_config(path: os.PathLike, branch: str = "main") -> dict:
         config = yaml.safe_load(stream)
 
     # make sure we at least have an input to the function
-    assert "X" in config["prediction_fn"]["args"].keys()
+    # assert "X" in config["prediction_fn"]["args"].keys()
 
     return config
 
@@ -81,3 +88,20 @@ def load_pretrained_model(
     install_package(config, allow_install=allow_install)
 
     return PretrainedModel(config)
+
+
+def load_dataset(
+    path: os.PathLike,
+    branch: str = "main"
+) -> intake.catalog.local.YAMLFileCatalog:
+    """Load a dataset from the path specified in scivision.yml."""
+    # parse the config file
+    # path = path + 'scivision.yml' #TODO: change _parse_config
+    config = _parse_url(path, branch=branch)
+    r = requests.get(config)
+    yaml_config = yaml.load(r.content, Loader=yaml.Loader)
+    yamlcatalog = YAMLFileCatalog(path='', autoreload=False)
+    yamlcatalog.from_dict(yaml_config)
+    return yamlcatalog
+    # print(config)
+    # return intake.open_catalog(r.content)

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -91,6 +91,8 @@ def load_pretrained_model(
 
 
 def load_dataset(
+    #TODO allow to load a local yaml OR GitHub yaml
+    #TODO use saving the yaml to a local tmp file
     path: os.PathLike,
     branch: str = "main"
 ) -> intake.catalog.local.YAMLFileCatalog:

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -26,8 +26,8 @@ def _parse_url(path: os.PathLike, branch: str = "main"):
     new_path = "/".join(split[:2]) + f"/{branch}/" + "/".join(split[2:])
     parsed = parsed._replace(path=new_path)
     return parsed.geturl()
-    
-    
+
+
 def _parse_config(path: os.PathLike, branch: str = "main") -> dict:
     """Parse the scivision.yml file from a GitHub repository.
     Will also accept differently named yaml if a full path provided or a local file.
@@ -75,7 +75,7 @@ def load_pretrained_model(
     with file as config_file:
         stream = config_file.read()
         config = yaml.safe_load(stream)
-    
+
     # make sure a model at least has an input to the function
     assert "X" in config["prediction_fn"]["args"].keys()
 
@@ -103,7 +103,7 @@ def load_dataset(
     intake.catalog.local.YAMLFileCatalog
         The intake catalog object from which an xarray dataset can be created.
     """
-    
+
     path = _parse_config(path, branch)
     # fsspec will throw an error if the path does not exist
     fsspec.open(path)

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -10,8 +10,6 @@ from ..koala import koala
 from .installer import install_package
 from .wrapper import PretrainedModel
 
-SCIVISION_YAML_CONFIG = ".scivision-config.yaml"
-
 
 def _is_url(path: os.PathLike) -> bool:
     return urlparse(path).scheme in ("http", "https",)

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -43,7 +43,7 @@ def _parse_config(path: os.PathLike, branch: str = "main", model_config=True) ->
         raise ValueError(f"Invalid configuration filename: {path}")
 
     if _is_url(path):
-        path = _parse_url(path)
+        path = _parse_url(path, branch)
 
     file = fsspec.open(path)
     with file as config_file:
@@ -92,7 +92,6 @@ def load_pretrained_model(
 
 
 def load_dataset(
-    #TODO allow to load a local yaml OR GitHub yaml
     path: os.PathLike,
     branch: str = "main"
 ) -> intake.catalog.local.YAMLFileCatalog:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -22,4 +22,4 @@ def test_load_dataset_local():
 def test_load_pretrained_model():
     """Test that scivision can load a pretrained model from an example GitHub repo."""
     # TODO: add tests for the methods in wrapper.py and installer.py
-    assert type(load_pretrained_model('https://github.com/quantumjot/scivision-test-plugin/.scivision-config_imagenet.yaml')) == wrapper.PretrainedModel
+    assert type(load_pretrained_model('https://github.com/quantumjot/scivision-test-plugin/.scivision-config_imagenet.yaml', allow_install=True)) == wrapper.PretrainedModel

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,7 +1,7 @@
-from scivision.io import load_dataset
+from scivision.io import load_dataset, load_pretrained_model, wrapper
 import intake
 
-
+#TODO: make the tests rely on specific commits from the example urls
 def test_load_dataset_remote():
     """Test that an intake catalog is generated from scivision.yml file in an example GitHub repo."""
     assert type(load_dataset('https://github.com/alan-turing-institute/intake-plankton')) == intake.catalog.local.YAMLFileCatalog
@@ -15,3 +15,9 @@ def test_load_dataset_branch_and_diff_file_name():
 def test_load_dataset_local():
     """Test that an intake catalog is generated from a local yml works."""
     assert type(load_dataset('tests/test_scivision.yml')) == intake.catalog.local.YAMLFileCatalog
+
+
+def test_load_pretrained_model():
+    """Test that scivision can load a pretrained model from an example GitHub repo."""
+    #TODO: add tests for the methods in wrapper.py and installer.py
+    assert type(load_pretrained_model('https://github.com/quantumjot/scivision-test-plugin/.scivision-config_imagenet.yaml')) == wrapper.PretrainedModel

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,15 +1,16 @@
 from scivision.io import load_dataset
 import intake
-import tempfile
 
 
 def test_load_dataset_remote():
     """Test that an intake catalog is generated from scivision.yml file in an example GitHub repo."""
     assert type(load_dataset('https://github.com/alan-turing-institute/intake-plankton')) == intake.catalog.local.YAMLFileCatalog
 
+
 def test_load_dataset_branch_and_diff_file_name():
     """Test that an intake catalog is generated when specifying a branch AND that a custom file name."""
     assert type(load_dataset('https://github.com/alan-turing-institute/intake-plankton/thESciViSionYAMLfileee.yaml', branch='diff-name-yml')) == intake.catalog.local.YAMLFileCatalog
+
 
 def test_load_dataset_local():
     """Test that an intake catalog is generated from a local yml works."""

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,16 @@
+from scivision.io import load_dataset
+import intake
+import tempfile
+
+
+def test_load_dataset_remote():
+    """Test that an intake catalog is generated from scivision.yml file in an example GitHub repo."""
+    assert type(load_dataset('https://github.com/alan-turing-institute/intake-plankton')) == intake.catalog.local.YAMLFileCatalog
+
+def test_load_dataset_branch_and_diff_file_name():
+    """Test that an intake catalog is generated when specifying a branch AND that a custom file name."""
+    assert type(load_dataset('https://github.com/alan-turing-institute/intake-plankton/thESciViSionYAMLfileee.yaml', branch='diff-name-yml')) == intake.catalog.local.YAMLFileCatalog
+
+def test_load_dataset_local():
+    """Test that an intake catalog is generated from a local yml works."""
+    assert type(load_dataset('tests/test_scivision.yml')) == intake.catalog.local.YAMLFileCatalog

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,7 +1,9 @@
 from scivision.io import load_dataset, load_pretrained_model, wrapper
 import intake
 
-#TODO: make the tests rely on specific commits from the example urls
+# TODO: make the tests rely on specific commits from the example urls
+
+
 def test_load_dataset_remote():
     """Test that an intake catalog is generated from scivision.yml file in an example GitHub repo."""
     assert type(load_dataset('https://github.com/alan-turing-institute/intake-plankton')) == intake.catalog.local.YAMLFileCatalog
@@ -19,5 +21,5 @@ def test_load_dataset_local():
 
 def test_load_pretrained_model():
     """Test that scivision can load a pretrained model from an example GitHub repo."""
-    #TODO: add tests for the methods in wrapper.py and installer.py
+    # TODO: add tests for the methods in wrapper.py and installer.py
     assert type(load_pretrained_model('https://github.com/quantumjot/scivision-test-plugin/.scivision-config_imagenet.yaml')) == wrapper.PretrainedModel

--- a/tests/test_scivision.yml
+++ b/tests/test_scivision.yml
@@ -1,0 +1,18 @@
+sources:
+  plankton_single:
+      description: Load a single labeled images from CEFAS zooplankton dataset
+      origin:
+      driver: intake_xarray.image.ImageSource
+      parameters:
+        kind:
+          description: which species to collect
+          type: str
+          default: Bivalvia-Larvae
+        id:
+          description: which filename
+          type: str
+          default: Pia1.2017-10-03.1726+N00296780_hc
+      args:
+        urlpath: './data/cefas-plankton-dsg-challenge/combined/images/{{kind}}/{{id}}.tif'
+        storage_options: {'anon': True}
+        exif_tags: True


### PR DESCRIPTION
Changes:

1. Update `load_pretrained_model` so that it accepts just the model repo url and knows to look for `scivision.yml`, or accepts a full path, including local.
2. Add `load_dataset` which takes a repo with an intake catalog, also called `scivision.yml`, or accepts a full path, including local.
3. Tests 2.
- [x] Test `load_pretrained_model`

Closes #73 

This was a todo, now created a separate issue:
- Add tests for other functions in `reader.py` -> #79