### PR TITLE
Use scivision@turing.ac.uk as contact email

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -42,7 +42,7 @@ Please open a GitHub issue to suggest a new feature, contribute code, or let us 
 ---
 
 This project is maintained by a team of researchers at The Alan Turing Institute.
-For any organisation related queries or concerns, you can directly reach out to the project team by emailing [xx](mailto:xx@turing.ac.uk).
+For any organisation related queries or concerns, you can directly reach out to the project team by emailing [the Scivison maintainers](mailto:scivision@turing.ac.uk).
 
 ♻️ License
 ---

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     version="0.0.1",
     description="scivision",
     author="Scivision Community",
-    author_email="scivision@unknown.invalid",
+    author_email="scivision@turing.ac.uk",
     url="https://github.com/alan-turing-institute/scivision",
     packages=find_packages(),
     install_requires=requirements,


### PR DESCRIPTION
Addresses @AidaMehonic's comment on [this PR](https://github.com/alan-turing-institute/scivision/pull/56)