### PR TITLE
Readthedocs API and repo README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Table of contents
 
 - [Installation and setup](#installation)
 - [How to contribute?](./contributing.md)
+- [Documentation](#documentation)
 
 ## Installation
 
@@ -71,3 +72,18 @@ Table of contents
     cd /path/to/my/scivision
     pip install -v -e .
     ```
+
+## Documentation
+
+Documentation is available at https://scivision.readthedocs.io/en/latest/
+
+Developers can build and view the docs locally by doing the following:
+
+#### Install requirements:
+1. `pip install sphinx`
+2. `pip install sphinx_rtd_theme`
+3. `pip install recommonmark`
+
+#### Then with scivision repo cloned
+1. In the top dir: `sphinx-build -b html docs/ build/`
+2. Open `build/index.html` in a browser

--- a/README.md
+++ b/README.md
@@ -77,19 +77,28 @@ Table of contents
 
 Documentation is available at https://scivision.readthedocs.io/en/latest/
 
-Developers can build and view the docs locally by doing the following:
+Developers can build and view the docs by doing the following:
 
-#### Install requirements:
-1. `pip install sphinx`
-2. `pip install sphinx_rtd_theme`
-3. `pip install recommonmark`
+1. **Install requirements**:
+  
+  ```bash
+  pip install sphinx
+  pip install sphinx_rtd_theme
+  pip install recommonmark
+  ```
 
-#### Then with scivision repo cloned
-1. In the top dir: `sphinx-build -b html docs/ build/`
-2. Open `build/index.html` in a browser
+2. **Build the docs**:
+  * In the top dir:
+  ```bash
+  sphinx-build -b html docs/ build/
+  ```
+  * The HTML will  be created in `build/`
 
-#### Update the API documentation
-1. Edit (or add) to the docstring of the function in question
-2. Ensure that the module containing that function has been added to `docs/api.rst`
+3. **Update the API documentation**:
+  * Edit (or add) to the docstring of the function in question
+  * Ensure that the module containing that function has been added to `docs/api.rst`
+  * Open `build/index.html` in a browser to view edits
+4. **Push the updates to the readthedocs site**:
+  * Create a pull request with your changes
+  * Upon merge to `main`, log into the https://readthedocs.org/projects/scivision/ dashboard as a maintainer and click `Builds->Build Version`
 
-### 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Table of contents
 
 ## Installation
 
-1. **install scivision via [PyPi](https://pypi.org/project/scivision/)**: which tends to be the most user-friendly option:
+1. **Install scivision via [PyPi](https://pypi.org/project/scivision/)**: which tends to be the most user-friendly option:
 
     ```bash
     pip install scivision
@@ -58,7 +58,7 @@ Table of contents
     pip install jupyter
     ```
 
-2. **install scivision from the source code**:
+2. **Install scivision from the source code**:
 
     * Clone scivision source code:
 
@@ -91,3 +91,5 @@ Developers can build and view the docs locally by doing the following:
 #### Update the API documentation
 1. Edit (or add) to the docstring of the function in question
 2. Ensure that the module containing that function has been added to `docs/api.rst`
+
+### 

--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ Developers can build and view the docs locally by doing the following:
 #### Then with scivision repo cloned
 1. In the top dir: `sphinx-build -b html docs/ build/`
 2. Open `build/index.html` in a browser
+
+#### Update the API documentation
+1. Edit (or add) to the docstring of the function in question
+2. Ensure that the module containing that function has been added to `docs/api.rst`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Table of contents
 - [Installation and setup](#installation)
 - [How to contribute?](./contributing.md)
 - [Documentation](#documentation)
+- [Releases](#releases)
+- [Maintainers](#maintainers)
 
 ## Installation
 
@@ -102,3 +104,31 @@ Developers can build and view the docs by doing the following:
   * Create a pull request with your changes
   * Upon merge to `main`, log into the https://readthedocs.org/projects/scivision/ dashboard as a maintainer and click `Builds->Build Version`
 
+## Releases
+
+Developers can release a new version of `scivision` with the following steps:
+
+1. **Increment the `version` in `setup.py` and any other metadata that differs for the new release**:
+2. **Make sure you have a working python 3 installation**
+    * Check your version with:
+    ```bash
+    python --version
+    ```
+3. **Install these packages if you don't have them**:
+   ```bash
+   pip install build twine
+   ```
+4. **Build the release**:
+   ```bash
+   python -m build
+   ```
+5. **Upload the release**:
+   ```bash
+   python -m twine upload dist/*
+   ```
+    * Provide your pypi username and password
+6. **Commit changes to `setup.py` pull request to `main` branch**
+
+## Maintainers
+
+If you are new to the `scivision` project and wish to become a maintainer for either the PyPi release or the  readthedocs documentation, send an email to scivision@turing.ac.uk

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,8 +3,5 @@ API
 
 This part of the documentation covers all the interfaces of scivision.
 
-.. automodule:: scivision
-   :members:
-
-.. automodule:: scivision.io
+.. automodule:: scivision.io.reader
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = "scivision"
 copyright = "2021, Alan Turing Institute"
-author = "Alan R Lowe, Alejandro Coca, Scott Hosking, Evangeline Corcoran, Beatriz Costa, Aida Mehonic, Miquel Massot"  # noqa
+author = "Alan R Lowe, Alejandro Coca, Scott Hosking, Evangeline Corcoran, Beatriz Costa, Aida Mehonic, Miquel Massot, Ed Chalstrey, Oliver Strickson, Kasra Hosseini"  # noqa
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "scivision"
 copyright = "2021, Alan Turing Institute"
 author = "Alan R Lowe, Alejandro Coca, Scott Hosking, Evangeline Corcoran, Beatriz Costa, Aida Mehonic, Miquel Massot, Ed Chalstrey, Oliver Strickson, Kasra Hosseini"  # noqa
-
+release = '0.1.2'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Updated how to update/maintain everything on the main README and added the `reader.py` functions to the API page of readthedocs.

Once I hit the build button after this PR gets merged, the docs will look like the below, which are auto-generated from the docstrings. I think at the moment I'll hold off on adding any other functions since they aren't user facing
![Screenshot 2022-01-13 at 16 43 57](https://user-images.githubusercontent.com/5486164/149372147-0da6ef94-48b9-4ce2-bd71-1e8634e7c6ae.png)

# TODO

- [ ] Build readthedocs after this PR merged
 