### PR TITLE
Add link to intake docs & update readthedocs requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,7 @@ Developers can build and view the docs by doing the following:
 1. **Install requirements**:
   
   ```bash
-  pip install sphinx
-  pip install sphinx_rtd_theme
-  pip install recommonmark
-  pip install m2r2
+  pip install -r readthedocs_requirements.txt
   ```
 
 2. **Build the docs**:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Developers can build and view the docs by doing the following:
 1. **Install requirements**:
   
   ```bash
-  pip install -r readthedocs_requirements.txt
+  pip install -r docs/requirements.txt
   ```
 
 2. **Build the docs**:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Developers can build and view the docs by doing the following:
   pip install sphinx
   pip install sphinx_rtd_theme
   pip install recommonmark
+  pip install m2r2
   ```
 
 2. **Build the docs**:

--- a/readthedocs_requirements.txt
+++ b/readthedocs_requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx_rtd_theme
+recommonmark
+m2r2

--- a/readthedocs_requirements.txt
+++ b/readthedocs_requirements.txt
@@ -1,4 +1,0 @@
-sphinx
-sphinx_rtd_theme
-recommonmark
-m2r2

--- a/scivision/io/reader.py
+++ b/scivision/io/reader.py
@@ -204,7 +204,7 @@ def load_dataset(
     Returns
     -------
     intake.catalog.local.YAMLFileCatalog
-        The intake catalog object from which an xarray dataset can be created.
+        An intake catalog object representing the loaded dataset (see `intake.readthedocs <https://intake.readthedocs.io/en/latest/api_user.html?highlight=catalog.local.YAMLFileCatalog#intake.catalog.local.YAMLFileCatalog>`_).
     """
 
     path = _parse_config(path, branch)


### PR DESCRIPTION
see PR title^

Weirdly I had to install an extra package called `m2r2` to build the docs which I didn't need to before... unsure why

Change to API doc:
![Screenshot 2022-01-25 at 10 56 53](https://user-images.githubusercontent.com/5486164/150964405-1f1cd54e-9674-4be0-b2b6-b78767d1de5f.png)

