### PR TITLE
[WIP] scivision notebook for DetectreeRGB use case

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,8 @@ dependencies:
   - aiohttp
   - intake
   - intake-xarray
+  - pytorch==1.8.0
+  - torchvision==0.9.0
+  - opencv
+  - pip:
+    - git+https://github.com/ESM-VFC/intake_zenodo_fetcher.git


### PR DESCRIPTION
Related issues: #156 

## Summary:
The example notebook refers to the [DetectreeRGB](https://github.com/shmh40/detectreeRGB) model authored by @shmh40. 

Some checks are needed i.e. reduce the length of preprocessing and visualisation steps, similar to `mapreader_plant_scivision.ipynb` and sort issues with `detectron2` library.

## TODO:
- [ ] @edwardchalstrey1 Could you please review the notebook? and add @shmh40 as contributor?
- [ ] Some packages to add in scivision `requirements.txt` are: `rasterio`, `pycurl`, `tqdm`, `git+https://github.com/ESM-VFC/intake_zenodo_fetcher.git`. These dependencies should be ready to use instead of declaring them in the `environment.yml `file. 
- [ ] It would be great to test new functionalities in scivision to provide ML-framework ready environments. For instance, the notebook uses `detectron2` which requires `pytorch`. See some ideas in #97.

## Machine:
I tested the notebook as a plain python file. I installed `scivision` via `pip install -e .` into a conda environment with `python 3.7`.