### PR TITLE
Notebook: MapReader to classify plant patches

### DIFF
--- a/examples/mapreader_plant_scivision.ipynb
+++ b/examples/mapreader_plant_scivision.ipynb
@@ -41,7 +41,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8244a270",
+   "id": "61ced77f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scivision_yml = 'https://raw.githubusercontent.com/alan-turing-institute/mapreader-plant-scivision/main/.scivision-config.yaml'\n",
+    "model = load_pretrained_model(scivision_yml, allow_install=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3fc5bdcc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "559e8c83",
+   "id": "837fb6eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,26 +92,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f809538e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scivision_yml = 'https://raw.githubusercontent.com/alan-turing-institute/mapreader-plant-scivision/main/.scivision-config.yaml'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8a545262",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = load_pretrained_model(scivision_yml, allow_install=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "9d13f857",
    "metadata": {
     "scrolled": false
@@ -123,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c58fa29",
+   "id": "616e1a32",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Closes #171 

- Added `installation` section in: https://github.com/alan-turing-institute/mapreader-plant-scivision
- Updated notebook so that it first install all required libraries

@evangeline-corcoran Could you please take a look at this?