### PR TITLE
add plankton dataset

### DIFF
--- a/scivision/catalog/data/datasources.json
+++ b/scivision/catalog/data/datasources.json
@@ -80,6 +80,26 @@
          "tags":[
             "demo"
          ]
+      },
+      {
+         "name":"data-004",
+         "description":"Sample dataset of Plankton required to demonstrate the Rapid Identification of Plankton using Machine Learning Project undertaken by CEFAS, The Alan Turing Institute and Plankton Analytics Ltd",
+         "tasks":[
+            "classification"
+         ],
+         "domains":[
+            "computer-vision"
+         ],
+         "url":"https://raw.githubusercontent.com/alan-turing-institute/plankton-cefas-scivision/test_data_catalog/scivision.yml",
+         "format":"image",
+         "labels_provided":true,
+         "institution":"Centre for Environment, Fisheries and Aquaculture Science (CEFAS)",
+         "tags":[
+            "2D",
+            "plankton",
+            "ecology",
+            "environmental-science"
+         ]
       }
    ]
 }


### PR DESCRIPTION
This PR refers to add the Plankton sample dataset from a [YAML file](https://github.com/alan-turing-institute/plankton-cefas-scivision). 

I am not sure which is the purpose of the field `labels`. However, for the Plankton dataset I left the default value `True` as  the class can be inferred from the filename. 