### PR TITLE
Add resnet-50 cefas model to scivision catalog

### DIFF
--- a/scivision/catalog/catalog.py
+++ b/scivision/catalog/catalog.py
@@ -49,7 +49,7 @@ class CatalogDatasourceEntry(BaseModel, extra="forbid"):
     url: Union[AnyUrl, FileUrl]
     format: str
     labels_provided: bool
-    institution: Optional[str]
+    institution: Optional[Tuple[str, ...]]
     tags: Tuple[str, ...]
 
     def __getitem__(self, item):

--- a/scivision/catalog/catalog.py
+++ b/scivision/catalog/catalog.py
@@ -28,7 +28,7 @@ class CatalogModelEntry(BaseModel, extra="forbid"):
     format: str
     pretrained: bool
     labels_required: bool
-    institution: Tuple[str, ...]
+    institution: Tuple[str, ...] = ()
     tags: Tuple[str, ...]
 
     def __getitem__(self, item):
@@ -49,7 +49,7 @@ class CatalogDatasourceEntry(BaseModel, extra="forbid"):
     url: Union[AnyUrl, FileUrl]
     format: str
     labels_provided: bool
-    institution: Tuple[str, ...]
+    institution: Tuple[str, ...] = ()
     tags: Tuple[str, ...]
 
     def __getitem__(self, item):

--- a/scivision/catalog/catalog.py
+++ b/scivision/catalog/catalog.py
@@ -28,7 +28,7 @@ class CatalogModelEntry(BaseModel, extra="forbid"):
     format: str
     pretrained: bool
     labels_required: bool
-    institution: Optional[str]
+    institution: Optional[Tuple[str, ...]]
     tags: Tuple[str, ...]
 
     def __getitem__(self, item):

--- a/scivision/catalog/catalog.py
+++ b/scivision/catalog/catalog.py
@@ -20,6 +20,13 @@ class TaskEnum(str, Enum):
 
 
 class CatalogModelEntry(BaseModel, extra="forbid"):
+    # tasks, institution and tags are Tuples (rather than Lists) so
+    # that they are immutable - Tuple is being used as an immutable
+    # sequence here. This means that these fields are hashable, which
+    # can be more convenient when included in a dataframe
+    # (e.g. unique()). Could consider using a Frozenset for these
+    # fields instead, since duplicates and ordering should not be
+    # significant.
     name: str
     description: Optional[str]
     tasks: Tuple[TaskEnum, ...]
@@ -38,12 +45,14 @@ class CatalogModelEntry(BaseModel, extra="forbid"):
 class CatalogModels(BaseModel, extra="forbid"):
     catalog_type: str = "scivision model catalog"
     name: str
+    # Tuple: see comment on CatalogModelEntry
     entries: Tuple[CatalogModelEntry, ...]
 
 
 class CatalogDatasourceEntry(BaseModel, extra="forbid"):
     name: str
     description: Optional[str]
+    # Tuple: see comment on CatalogModelEntry
     tasks: Tuple[TaskEnum, ...]
     domains: Tuple[str, ...]
     url: Union[AnyUrl, FileUrl]
@@ -59,6 +68,7 @@ class CatalogDatasourceEntry(BaseModel, extra="forbid"):
 class CatalogDatasources(BaseModel, extra="forbid"):
     catalog_type: str = "scivision datasource catalog"
     name: str
+    # Tuple: see comment on CatalogModelEntry
     entries: Tuple[CatalogDatasourceEntry, ...]
 
 

--- a/scivision/catalog/catalog.py
+++ b/scivision/catalog/catalog.py
@@ -28,7 +28,7 @@ class CatalogModelEntry(BaseModel, extra="forbid"):
     format: str
     pretrained: bool
     labels_required: bool
-    institution: Optional[Tuple[str, ...]]
+    institution: Tuple[str, ...]
     tags: Tuple[str, ...]
 
     def __getitem__(self, item):
@@ -49,7 +49,7 @@ class CatalogDatasourceEntry(BaseModel, extra="forbid"):
     url: Union[AnyUrl, FileUrl]
     format: str
     labels_provided: bool
-    institution: Optional[Tuple[str, ...]]
+    institution: Tuple[str, ...]
     tags: Tuple[str, ...]
 
     def __getitem__(self, item):

--- a/scivision/catalog/data/datasources.json
+++ b/scivision/catalog/data/datasources.json
@@ -93,7 +93,7 @@
          "url":"https://raw.githubusercontent.com/alan-turing-institute/plankton-cefas-scivision/test_data_catalog/scivision.yml",
          "format":"image",
          "labels_provided":true,
-         "institution":"Centre for Environment, Fisheries and Aquaculture Science (CEFAS)",
+         "institution":["Centre for Environment, Fisheries and Aquaculture Science (CEFAS)"],
          "tags":[
             "2D",
             "plankton",

--- a/scivision/catalog/data/datasources.json
+++ b/scivision/catalog/data/datasources.json
@@ -14,7 +14,7 @@
          "url":"https://github.com/stardist/stardist/releases/download/0.3.0/demo3D.zip",
          "format":"image",
          "labels_provided":true,
-         "institution":"epfl",
+         "institution":["epfl"],
          "tags":[
             "help-needed",
             "3D",
@@ -38,7 +38,7 @@
          "url":"https://gitlab.au.dk/AUENG-Vision/OPPD/-/archive/master/OPPD-master.zip?path=DATA/images_plants/1COMF",
          "format":"image",
          "labels_provided":true,
-         "institution":"Aarhus University",
+         "institution":["Aarhus University"],
          "tags":[
             "help-needed",
             "2D",
@@ -58,7 +58,7 @@
          "url":"https://github.com/scotthosking/intake-plankton/blob/main/plktn.yaml",
          "format":"image",
          "labels_provided":true,
-         "institution":"CEFAS",
+         "institution":["CEFAS"],
          "tags":[
             "help-needed",
             "2D"
@@ -76,7 +76,7 @@
          "url":"https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/Cutest_Koala.jpg/262px-Cutest_Koala.jpg",
          "format":"image",
          "labels_provided":true,
-         "institution":"Wikipedia by Erik Veland",
+         "institution":["Wikipedia by Erik Veland"],
          "tags":[
             "demo"
          ]

--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -10,7 +10,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":true,
-            "institution":"epfl",
+            "institution":["epfl"],
             "tags": ["2D", "3D", "optical-microscopy", "xray", "microtomography", "cell-counting", "plant-phenotyping", "climate-change-and-agriculture"]
         },
         {
@@ -21,7 +21,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":true,
-            "institution":"danforthcenter",
+            "institution":["danforthcenter"],
             "tags": ["2D", "hyperspectral", "multispectral", "near-infrared","infrared","plant-phenotyping", "climate-change-and-agriculture"]
         },
         {
@@ -32,7 +32,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":true,
-            "institution":"MarniTausen",
+            "institution":["MarniTausen"],
             "tags": ["2D", "multispectral", "plant-phenotyping", "climate-change-and-agriculture"]
         },
         {
@@ -43,7 +43,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":true,
-            "institution":"alan-turing-institute",
+            "institution":["alan-turing-institute"],
             "tags": ["dummy"]
         },
         {
@@ -54,7 +54,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":false,
-            "institution":"alan-turing-institute",
+            "institution":["alan-turing-institute"],
             "tags": ["dummy"]
         },
         {
@@ -66,7 +66,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":false,
-            "institution":"alan-turing-institute",
+            "institution":["alan-turing-institute"],
             "tags":["2D", "plant", "phenotype", "rgb", "biology", "agriculture"]
         },
         {

--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -68,6 +68,18 @@
             "labels_required":false,
             "institution":"alan-turing-institute",
             "tags":["2D", "plant", "phenotype", "rgb", "biology", "agriculture"]
+        },
+        {
+            "name":"resnet50-plantkton",
+            "description":"automated classification of plankton images collected by RV Cefas Endeavour Plankton Imager in three clases: copepod, non-copepod and detritus",
+            "tasks":["classification"],
+            "url":"https://github.com/alan-turing-institute/plankton-cefas-scivision",
+            "pkg_url":"git+https://github.com/alan-turing-institute/plankton-cefas-scivision@master",
+            "format":"image",
+            "pretrained":true,
+            "labels_required":false,
+            "institution":["alan-turing-institute", "cefas", "plankton-analytics-ltd"],
+            "tags": ["2D", "plankton", "ecology", "environmental-science"]
         }
     ]
 }


### PR DESCRIPTION
This PR refers to add the [resnet-50 cefas model plugin](https://github.com/alan-turing-institute/plankton-cefas-scivision) for classifying plankton images. 

Note I added multiple elements in the `institution` field. 