### PR TITLE
fix misspelling in name for vedge detector model

### DIFF
--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -82,7 +82,7 @@
             "tags": ["2D", "plankton", "ecology", "environmental-science"]
         },
         {
-            "name":"vegde-detector",
+            "name":"vedge-detector",
             "description":"automated detection of coastal vegetation edges in remote sensing imagery",
             "tasks":["segmentation"],
             "url":"https://github.com/MartinSJRogers/VEdge_Detector_scivision",


### PR DESCRIPTION
This PR fixes the name of the vedge detector model in the scivision model catalog.