### PR TITLE
Release scivision 0.1.3

### DIFF
--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -15,7 +15,7 @@ If you are new to the `scivision` project and wish to become a maintainer for ei
 
 Developers of `scivision` with maintainer access to https://github.com/alan-turing-institute/scivision & https://pypi.org/project/scivision can release a new version of the package with the following steps:
 
-1. Increment the `version` in `setup.py` and any other metadata that differs for the new release.
+1. On a new branch of the `scivision` repo, increment the `version` in `setup.py` and any other metadata that differs for the new release.
 
 2. Make sure you have a working python 3 installation. Check your version with:
     
@@ -38,7 +38,7 @@ Developers of `scivision` with maintainer access to https://github.com/alan-turi
    python -m twine upload dist/<version>*
    ```
     * Note: You'll need to provide your PyPi username and password
-6. Commit changes to `setup.py` pull request to the `main` branch of https://github.com/alan-turing-institute/scivision
+6. Commit changes to `setup.py` and pull request to the `main` branch of https://github.com/alan-turing-institute/scivision
 
 .. _building:
 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -32,7 +32,7 @@ Developers of `scivision` with maintainer access to https://github.com/alan-turi
    ```bash
    python -m build
    ```
-5. Upload the release, substituring `<version>` with the new version number:
+5. Upload the release, substituting `<version>` with the new version number:
 
    ```bash
    python -m twine upload dist/<version>*

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -32,10 +32,10 @@ Developers of `scivision` with maintainer access to https://github.com/alan-turi
    ```bash
    python -m build
    ```
-5. Upload the release:
+5. Upload the release, substituring `<version>` with the new version number:
 
    ```bash
-   python -m twine upload dist/*
+   python -m twine upload dist/<version>*
    ```
     * Note: You'll need to provide your PyPi username and password
 6. Commit changes to `setup.py` pull request to the `main` branch of https://github.com/alan-turing-institute/scivision

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="scivision",
-    version="0.1.2",
+    version="0.1.3",
     description="scivision",
     author="The Alan Turing Institute",
     author_email="scivision@turing.ac.uk",


### PR DESCRIPTION
scivision 0.1.3 has been released at https://pypi.org/project/scivision/

This PR updates the version number on GitHub and makes some minor changes to docs