### PR TITLE
Automate PyPI upload

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,30 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        twine
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -13,6 +13,22 @@ If you are new to the `scivision` project and wish to become a maintainer for ei
 
 ## 🐍 Python package releases
 
+A new release of the scivision package will be uploaded to PyPi each time a tagged commit is pushed to the main branch of the [scivision GitHub repo](https://github.com/alan-turing-institute/scivision). In order to trigger this automated process, do the following:
+
+1. On a new branch of the `scivision` repo containing your changes to be included in the release, tag the latest commit like so (where `<tag_name>` is an appropriate version number - see [PyPI](https://pypi.org/project/scivision/)):
+    
+    ```bash
+    git tag <tag_name> <commit_sha>
+    ```
+
+2. Push the branch to GitHub:
+    
+    ```bash
+    git push --tags
+    ```
+
+3. Create a pull request. Upon merge to the `main` branch, the new release should be uploaded.
+
 Developers of `scivision` with maintainer access to https://github.com/alan-turing-institute/scivision & https://pypi.org/project/scivision can release a new version of the package with the following steps:
 
 1. On a new branch of the `scivision` repo, increment the `version` in `setup.py` and any other metadata that differs for the new release.

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -7,13 +7,13 @@ This document is intended for maintainers of the scivision project and includes 
 1. :ref:`releasing`
 2. :ref:`building`
 
-If you are new to the `scivision` project and wish to become a maintainer for either the `PyPi` release or the  `readthedocs` documentation, send an email to scivision@turing.ac.uk
+If you are new to the `scivision` project and wish to become a maintainer for either the `PyPI` release or the  `readthedocs` documentation, send an email to scivision@turing.ac.uk
 
 .. _releasing:
 
 ## 🐍 Python package releases
 
-A new release of the scivision package will be uploaded to PyPi each time a tagged commit is pushed to the main branch of the [scivision GitHub repo](https://github.com/alan-turing-institute/scivision). In order to trigger this automated process, do the following:
+A new release of the scivision package will be uploaded to PyPI each time a tagged commit is pushed to the main branch of the [scivision GitHub repo](https://github.com/alan-turing-institute/scivision). In order to trigger this automated process, do the following:
 
 1. On a new branch of the `scivision` repo containing your changes to be included in the release, tag the latest commit like so (where `<tag_name>` is an appropriate version number - see [PyPI](https://pypi.org/project/scivision/)):
     
@@ -29,7 +29,7 @@ A new release of the scivision package will be uploaded to PyPi each time a tagg
 
 3. Create a pull request. Upon merge to the `main` branch, the new release should be uploaded.
 
-Developers of `scivision` with maintainer access to https://github.com/alan-turing-institute/scivision & https://pypi.org/project/scivision can manually release a new version of the package with the following steps:
+Alternatively, developers of `scivision` with maintainer access to https://github.com/alan-turing-institute/scivision & https://pypi.org/project/scivision can manually release a new version of the package with the following steps:
 
 1. On a new branch of the `scivision` repo, increment the `version` in `setup.py` and any other metadata that differs for the new release.
 
@@ -53,7 +53,7 @@ Developers of `scivision` with maintainer access to https://github.com/alan-turi
    ```bash
    python -m twine upload dist/<version>*
    ```
-    * Note: You'll need to provide your PyPi username and password
+    * Note: You'll need to provide your PyPI username and password
 6. Commit changes to `setup.py` and pull request to the `main` branch of https://github.com/alan-turing-institute/scivision
 
 .. _building:

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -29,7 +29,7 @@ A new release of the scivision package will be uploaded to PyPi each time a tagg
 
 3. Create a pull request. Upon merge to the `main` branch, the new release should be uploaded.
 
-Developers of `scivision` with maintainer access to https://github.com/alan-turing-institute/scivision & https://pypi.org/project/scivision can release a new version of the package with the following steps:
+Developers of `scivision` with maintainer access to https://github.com/alan-turing-institute/scivision & https://pypi.org/project/scivision can manually release a new version of the package with the following steps:
 
 1. On a new branch of the `scivision` repo, increment the `version` in `setup.py` and any other metadata that differs for the new release.
 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -21,10 +21,11 @@ A new release of the scivision package will be uploaded to PyPI each time a tagg
     git tag <tag_name> <commit_sha>
     ```
 
-2. Push the branch to GitHub:
+2. Push both the changes on the branch and the tags to GitHub:
     
     ```bash
     git push --tags
+    git push   # or however you would usually push a branch
     ```
 
 3. Create a pull request. Upon merge to the `main` branch, the new release should be uploaded.


### PR DESCRIPTION
- Closes #86 
- Adds PyPI publishing job to GH actions: tagged commits will initiate a new release
- Tags a commit with `0.2.0` to test this, so should close #199 
- Updates the readthedocs