### PR TITLE
Revert "Use main branch, not master for PyPI release GH actions"

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,6 +25,6 @@ jobs:
         build
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@main
+      uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Reverts alan-turing-institute/scivision#210

Ok I misunderstood this - I think `@master` is the branch of the GH action, not the scivision repo, so it should not be `@main`