### PR TITLE
Add image-classifiers models repo to catalog

### DIFF
--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -95,7 +95,7 @@
         },
         {
             "name":"scivision_classifier",
-            "tasks":["object-detection"],
+            "tasks":["classification"],
             "url":"https://github.com/alan-turing-institute/scivision_classifier",
             "pkg_url":"git+https://github.com/alan-turing-institute/scivision_classifier.git@main",
             "format":"image",

--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -92,6 +92,17 @@
             "labels_required":false,
             "institution":["cambridge-university", "birkbeck-university"],
             "tags": ["2D", "satellite", "remote-sensing", "ecology", "environmental-science"]
+        },
+        {
+            "name":"scivision_classifier",
+            "tasks":["object-detection"],
+            "url":"https://github.com/alan-turing-institute/scivision_classifier",
+            "pkg_url":"git+https://github.com/alan-turing-institute/scivision_classifier.git@main",
+            "format":"image",
+            "pretrained":true,
+            "labels_required":false,
+            "institution":["alan-turing-institute"],
+            "tags": ["classification", "2D", "image"]
         }
     ]
 }

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="scivision",
-    version="0.2.3",
+    version="0.2.4",
     description="scivision",
     author="The Alan Turing Institute",
     author_email="scivision@turing.ac.uk",


### PR DESCRIPTION
I've created a new plugin, directly inspired by @quantumjot's original one (and some code borrowed), which enables loading of any model from https://pypi.org/project/image-classifiers/ via the scivision interface and provides a rudimentary predict function: https://github.com/alan-turing-institute/scivision_classifier 

We could take a similar approach for other packages/frameworks without too much effort, see #218

Some manual effort was required to fit the repo to the scivision specification (see how I had to add each model name to 3 places: model.py, model.yml & __init__.py !), but this might not be something we need to worry about too much if we only want to add an entire package/framework's model selections to scivision for a few select cases.

Interested to hear people's thoughts on this!


I also incremented the release number so this can go straight to PyPI on merge as per [docs](https://scivision.readthedocs.io/en/latest/maintainers.html#python-package-releases)