### PR TITLE
Add reinstall step

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: scivision
 channels:
   - conda-forge
+  - anaconda
 dependencies:
   - python=3.9
   - matplotlib
@@ -13,3 +14,7 @@ dependencies:
   - aiohttp
   - intake
   - intake-xarray
+  - jupyter
+  - pip
+  - pip:
+    - scivision

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,3 @@ dependencies:
   - intake
   - intake-xarray
   - jupyter
-  - pip
-  - pip:
-    - scivision

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,5 +2,11 @@
 
 This directory contains:
   - [scivision-core-functionality.ipynb](./scivision-core-functionality.ipynb): a notebook demonstrating essential Scivision functionality
+  
+To run any of the notebooks in this directory locally, do the following:
+
+- `conda env create -f ../environment.yml`
+- `conda activate scivision`
+-  `jupyter notebook`
 
 **Visit the [Scivision Gallery](https://github.com/scivision-gallery) to see more examples and use-cases.**

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,10 +3,11 @@
 This directory contains:
   - [scivision-core-functionality.ipynb](./scivision-core-functionality.ipynb): a notebook demonstrating essential Scivision functionality
   
-To run any of the notebooks in this directory locally, do the following:
+To run any of the notebooks in this directory locally, do the following, from the top level of this repo:
 
-- `conda env create -f ../environment.yml`
-- `conda activate scivision`
--  `jupyter notebook`
+1. Install scivision: `pip install -v -e .`
+2. Create the environment for the notebooks: `conda env create -f environment.yml`
+3. Activate it: `conda activate scivision`
+4. Open the notebook in `/examples` with `jupyter notebook`
 
 **Visit the [Scivision Gallery](https://github.com/scivision-gallery) to see more examples and use-cases.**

--- a/scivision/catalog/data/datasources.json
+++ b/scivision/catalog/data/datasources.json
@@ -68,7 +68,8 @@
          "name":"data-003",
          "description":"Koala",
          "tasks":[
-            "object-detection"
+            "object-detection",
+            "classification"
          ],
          "domains":[
             "computer-vision"

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -28,16 +28,21 @@ def package_from_config(config: dict, branch: str = "main") -> str:
 def _install(package):
     """Install a package using pip."""
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+    
+    
+def _uninstall(package):
+    """Install a package using pip."""
+    subprocess.check_call([sys.executable, "-m", "pip", "uninstall", package])
 
 
 def install_package(config: dict, allow_install: bool = False, branch: str = "main"):
     """Install the python package if it doesn't exist."""
-
-    # now check to see whether the package exists
-    if not _package_exists(config):
-
-        package = package_from_config(config, branch)
-
+    package = package_from_config(config, branch)
+    if _package_exists(config):  # only reinstall if allow_install is True
+        if allow_install:
+            _uninstall(package)
+            _install(package)
+    else:
         if allow_install:
             _install(package)
         else:

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -32,7 +32,9 @@ def _install(package):
 
 def _reinstall(package):
     """Reinstall a package using pip."""
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", "--no-cache-dir", "--ignore-installed", "--no-deps", package])
+    subprocess.check_call([sys.executable, "-m", "pip", "install",
+                           "--force-reinstall", "--no-cache-dir",
+                           "--ignore-installed", "--no-deps", package])
 
 
 def install_package(config: dict, allow_install: bool = False, branch: str = "main"):

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -27,7 +27,7 @@ def package_from_config(config: dict, branch: str = "main") -> str:
 
 def _install(package):
     """Install a package using pip."""
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", "--no-cache-dir", package])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", "--no-cache-dir", "--ignore-installed", package])
 
 
 # def _uninstall(github_url):

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -28,8 +28,8 @@ def package_from_config(config: dict, branch: str = "main") -> str:
 def _install(package):
     """Install a package using pip."""
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-    
-    
+
+
 def _uninstall(github_url):
     """Uninstall a package using pip."""
     package_name = github_url.split('/')[-1]

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -27,13 +27,12 @@ def package_from_config(config: dict, branch: str = "main") -> str:
 
 def _install(package):
     """Install a package using pip."""
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", "--no-cache-dir", "--ignore-installed", package])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
 
-# def _uninstall(github_url):
-#     """Uninstall a package using pip."""
-#     package_name = github_url.split('/')[-1]
-#     subprocess.check_call([sys.executable, "-m", "pip", "uninstall", package_name])
+def _reinstall(package):
+    """Reinstall a package using pip."""
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", "--no-cache-dir", "--ignore-installed", "--no-deps", package])
 
 
 def install_package(config: dict, allow_install: bool = False, branch: str = "main"):
@@ -41,8 +40,7 @@ def install_package(config: dict, allow_install: bool = False, branch: str = "ma
     package = package_from_config(config, branch)
     if _package_exists(config):  # only reinstall if allow_install is True
         if allow_install:
-            # _uninstall(config['url'])
-            _install(package)
+            _reinstall(package)
     else:
         if allow_install:
             _install(package)

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -27,13 +27,13 @@ def package_from_config(config: dict, branch: str = "main") -> str:
 
 def _install(package):
     """Install a package using pip."""
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", "--no-cache-dir", package])
 
 
-def _uninstall(github_url):
-    """Uninstall a package using pip."""
-    package_name = github_url.split('/')[-1]
-    subprocess.check_call([sys.executable, "-m", "pip", "uninstall", package_name])
+# def _uninstall(github_url):
+#     """Uninstall a package using pip."""
+#     package_name = github_url.split('/')[-1]
+#     subprocess.check_call([sys.executable, "-m", "pip", "uninstall", package_name])
 
 
 def install_package(config: dict, allow_install: bool = False, branch: str = "main"):
@@ -41,7 +41,7 @@ def install_package(config: dict, allow_install: bool = False, branch: str = "ma
     package = package_from_config(config, branch)
     if _package_exists(config):  # only reinstall if allow_install is True
         if allow_install:
-            _uninstall(config['url'])
+            # _uninstall(config['url'])
             _install(package)
     else:
         if allow_install:

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -30,9 +30,10 @@ def _install(package):
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
     
     
-def _uninstall(package):
-    """Install a package using pip."""
-    subprocess.check_call([sys.executable, "-m", "pip", "uninstall", package])
+def _uninstall(github_url):
+    """Uninstall a package using pip."""
+    package_name = github_url.split('/')[-1]
+    subprocess.check_call([sys.executable, "-m", "pip", "uninstall", package_name])
 
 
 def install_package(config: dict, allow_install: bool = False, branch: str = "main"):
@@ -40,7 +41,7 @@ def install_package(config: dict, allow_install: bool = False, branch: str = "ma
     package = package_from_config(config, branch)
     if _package_exists(config):  # only reinstall if allow_install is True
         if allow_install:
-            _uninstall(package)
+            _uninstall(config['url'])
             _install(package)
     else:
         if allow_install:

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -33,8 +33,7 @@ def _install(package):
 def _reinstall(package):
     """Reinstall a package using pip."""
     subprocess.check_call([sys.executable, "-m", "pip", "install",
-                           "--force-reinstall", "--no-cache-dir",
-                           "--ignore-installed", "--no-deps", package])
+                           "--force-reinstall", "--no-deps", package])
 
 
 def install_package(config: dict, allow_install: bool = False, branch: str = "main"):


### PR DESCRIPTION
### Changes

1. Closes #221 by adding a `_reinstall` function: when you do `load_pretrained_model('path/to/repo', allow_install=True)`, it will reinstall it when running a second time, but not when allow_install=False
2. Edits the Koala catalog entry so it matches on the "classification" task, so it appears in results when using `scivision_classifier` models (see `models.json`)
3. Updates instructions for running example notebook locally - it wasn't clear already that you'd need to have the environment in the `environment.yml` built/activated, which installs `intake-xarray` via conda-forge (the binder version does this)