### PR TITLE
Contributing guide changes

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -8,8 +8,6 @@ Thank you for taking the time to contribute to the scivision project. 🎉
 - :ref:`what-to-contribute`
 - :ref:`how-to-contribute`
 - :ref:`extending-the-scivision-catalog`
-- :ref:`contact`
-- :ref:`licence-header`
 
 .. _who-should-contribute:
 

--- a/contributing.md
+++ b/contributing.md
@@ -14,43 +14,50 @@ Thank you for taking the time to contribute to the scivision project. 🎉
 😎 Who should contribute
 ---
 
-The scivision project is being developed openly and invites contributions from anyone with prior experience in computer vision or scientific disciplines represented in the project.
+The scivision project is being developed openly and invites contributions from anyone interested in computer vision or scientific data, who agrees with the goal of making models and datasets more accessible and discoverable across disciplines!
 
-In particular we'd like to encourage contributions from the following people:
+The following contributions are particularly welcome:
 
-1. **Model developers** of computer vision models
-2. **Data providers** from diverse scientific fields
-3. **Programmers** interested in improving the scivision package
-
-Members of the first two groups should pay particular attention to the :ref:`extending-the-scivision-catalog` section of this guide.
+* **Computer vision models** for the model catalog, whether new or existing
+* **Data sources** for the data catalog, from the sciences or humanities
+* New features or other code improvements to the scivision package itself
+* Bug reports
 
 .. _what-to-contribute:
 
 🤔 What to contribute
 ---
 
-#### 1) Catalog contributions
+#### Catalog contributions
 
-We call upon the developers of computer vision **models** to make a submission to the scivision catalog. Submitting your model will allow scivision users to query the catalog for datasets on which your model can be run, or to find your model based on their own dataset submission.
+Submit a model or dataset to the catalog so that they are discoverable by other scivision users when querying the catalog.
 
-Similarly, we call upon data providers from diverse scientific fields to consider submitting open **datasets** to the catalog.
+See :ref:`extending-the-scivision-catalog`.
 
-Models and datasets from the catalog are matched based on the model task, data format and other labels.
+#### Bug reports
 
-To understand how to submit a catalog entry (model or dataset), see: :ref:`extending-the-scivision-catalog`.
+First, please check the [open issues](https://github.com/alan-turing-institute/scivision/issues) in case the bug has already been reported.
 
-#### 2) Code improvements
+If not, then [open a new issue here](https://github.com/alan-turing-institute/scivision/issues/new/choose).
 
-We encourage programmers interested in the scivision package to submit bug-fixes, new code features and documentation improvements (including fixing any typos and broken links).
+#### Code and documentation contributions
 
-To get started, please take a look at our currently open [issues](https://github.com/alan-turing-institute/scivision/issues) and participate in ongoing [discussions](https://github.com/alan-turing-institute/scivision/discussions) by commenting. Feel free to open a new issue to suggest a feature, or let us know about any bugs you encounter.
+Additional features, code quality improvements, issues, typos, documentation improvements are all welcome.
+
+To get started:
+ * Consider starting a [discussion](https://github.com/alan-turing-institute/scivision/discussions), to get feedback on your idea, or participating in an ongoing one
+ * Look for any relevant [issues](https://github.com/alan-turing-institute/scivision/issues).
+
+Pull requests are welcome: see :ref:`how-to-contribute` which describes our workflow.
+
+For larger features, substantial changes, or anything where you would like early feedback from the community, consider starting a Scivision Improvement Proposal.  :ref:`about-scips`.  Feel free to ask for advice about this in an issue/discussion.
 
 .. _how-to-contribute:
 
-🛠 How to contribute
+🛠 How to contribute changes to this repository
 ---
 
-- To contribute to this repository, open a [Pull Request](https://github.com/alan-turing-institute/scivision/pulls).
+- Open a [Pull Request](https://github.com/alan-turing-institute/scivision/pulls).
 
 - Our basic workflow is [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow).  In particular:
   - The branch `main` always contain the latest working version of the package.
@@ -70,15 +77,15 @@ To get started, please take a look at our currently open [issues](https://github
 🎁 Extending the scivision catalog
 ---
 
-You can add models or datasets to the scivision catalog via the GitHub workflow discussed in this guide (see :ref:`how-to-contribute`).
+You can add models or datasets to the scivision catalog via the GitHub workflow described above.
 
-#### Preparing a model for inclusion in the catalog:
+#### Preparing a model for inclusion in the catalog
 
 In order to submit a model to the scivision catalog, you must first set up the GitHub repository containing the model as per the :ref:`model-repo-template`.
 
 This will enable you load your model via the scivision API and run it on matching datasets present in the catalog.
 
-#### Submitting your model to the catalog:
+#### Submitting your model to the catalog
 
 Once you have prepared a model for inclusion in the catalog, you can submit it via the following steps. Once your model submission is accepted, it will become available to other users of scivision.
 
@@ -103,13 +110,13 @@ Fork the [scivision repository](https://github.com/alan-turing-institute/scivisi
 
 After you are done, create a pull request with the changes. A scivision maintainer will approve the addition, making it available to all scivision users.
 
-#### Preparing a dataset for inclusion in the catalog:
+#### Preparing a dataset for inclusion in the catalog
 
 In order to submit a dataset to the scivision catalog, you must first set up a GitHub repository containing important metadata as per the :ref:`data-repo-template`.
 
 This will enable you load your dataset via the scivision API and run matching models from catalog on it.
 
-#### Adding a new dataset to the catalog:
+#### Adding a new dataset to the catalog
 
 Once you have prepared a dataset for inclusion in the catalog, you can submit it via the following steps. Once your submission is accepted, the dataset will become available to other users of scivision.
 

--- a/docs/about_scips.rst
+++ b/docs/about_scips.rst
@@ -4,14 +4,14 @@ About Scivision Improvement Proposals (SCIPs)
 What is a SCIP?
 ---------------
 
-A SCIP, or *Scivision Improvement Proposal*, is a document describing a *standard* for the project: either one that has been accepted and adopted, or that has been suggested.  It is similar to an RFC (Request for Comments) used in other projects, or a PEP (Python Enhancement Proposal) in the Python ecosystem.  A SCIP could describe:
+A SCIP, or *Scivision Improvement Proposal*, is a document describing a standard for the project: either one that has been accepted and adopted, or that has been suggested.  It is similar to an RFC (Request for Comments) used in other projects, or a PEP (Python Enhancement Proposal) in the Python ecosystem.  A SCIP could describe:
 
     * software architecture
     * an interface or API that the software exposes
     * a file format
     * a process or way of working together.
 
-SCIPs that have been adopted (whose *status* is 'stable') complement the project documentation, where relevant SCIPs can be linked and referenced.  Unlike the documentation, they are intended as *normative specifications*, and can be used by implementors to understand the intended behaviour of the system.
+SCIPs that have been adopted (whose *status* is 'stable') complement the project documentation, where relevant SCIPs can be linked and referenced.  Unlike the documentation, they are intended as specifications, and can be used by implementors to understand the intended behaviour of the system.
 
 When should a SCIP be used?
 ---------------------------

--- a/docs/about_scips.rst
+++ b/docs/about_scips.rst
@@ -1,3 +1,5 @@
+.. _about-scips:
+
 About Scivision Improvement Proposals (SCIPs)
 =============================================
 

--- a/docs/about_scips.rst
+++ b/docs/about_scips.rst
@@ -1,11 +1,15 @@
-Scivision Improvement Proposals (SCIPs)
-=======================================
+About Scivision Improvement Proposals (SCIPs)
+=============================================
+
+What is a SCIP?
+---------------
 
 A SCIP, or *Scivision Improvement Proposal*, is a document describing a *standard* for the project: either one that has been accepted and adopted, or that has been suggested.  It is similar to an RFC (Request for Comments) used in other projects, or a PEP (Python Enhancement Proposal) in the Python ecosystem.  A SCIP could describe:
-  - software architecture
-  - an interface or API that the software exposes
-  - a file format
-  - a process or way of working together.
+
+    * software architecture
+    * an interface or API that the software exposes
+    * a file format
+    * a process or way of working together.
 
 SCIPs that have been adopted (whose *status* is 'stable') complement the project documentation, where relevant SCIPs can be linked and referenced.  Unlike the documentation, they are intended as *normative specifications*, and can be used by implementors to understand the intended behaviour of the system.
 
@@ -31,7 +35,7 @@ We use the `Consensus Oriented Specification System <https://rfc.unprotocols.org
 In summary, the steps to follow, from proposal to adoption, are listed below. Feel free to ask on the `discussions board <https://github.com/alan-turing-institute/scivision/discussions>`_ if you need any help with any part of this process.
 
  #. Fork/clone this repository
- #. Copy the `template SCIP <scip/0000-template.md>`_ to a file in `docs/scip <./docs/scip>`_ (using the next available number for the filename: something like ``0123-short-name.md``)
+ #. Copy the template from ``docs/scip/0000-template.md`` to a new file in ``docs/scip`` (relative to the project root).  Use the next available number for the filename, for example ``0123-short-name.md``
  #. Add your GitHub username to the ``editor`` field (or the username of whoever has agreed to be the editor)
  #. Give it a short, descriptive title, and optionally add any draft text to the relevant sections of the document
  #. Open a pull request into this repository
@@ -40,4 +44,5 @@ In summary, the steps to follow, from proposal to adoption, are listed below. Fe
  #. Consider `discussing <https://github.com/alan-turing-institute/scivision/discussions>`_ the proposal with the community, and requesting feedback or edits from  others as pull requests into this repository
  #. When it is ready for work to begin on an implementation, change (via pull request) the status to ``draft``
  #. Once there is broad agreement that it should be adopted (and a working implementation, for code changes), change the status to ``stable``.
+
      * Substantial edits should not be made to SCIPs whose status is ``stable``.  Instead, create a new one as a replacement (using this process), perhaps copying and modifying any relevant text, and eventually deprecating/retiring the original.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,4 @@
+
 .. oplab_pipeline documentation master file, created by
    sphinx-quickstart on Thu May  7 19:32:18 2020.
 
@@ -38,6 +39,7 @@ This Scivision documentation is hosted on `Read the Docs <https://scivision.read
    user_guide
    api
    contributing
+   scips
    model_repository_template
    data_repository_template
    maintainers

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,9 +39,9 @@ This Scivision documentation is hosted on `Read the Docs <https://scivision.read
    user_guide
    api
    contributing
-   scips
    model_repository_template
    data_repository_template
+   scip_index
    maintainers
 
 📷 Background

--- a/docs/scip/0000-template.md
+++ b/docs/scip/0000-template.md
@@ -1,0 +1,17 @@
+# 0/Template
+
+## Metadata
+
+Editor:
+  (Your name or GitHub handle)
+
+Status (raw | draft | stable | deprecated | retired):
+  raw
+
+## Description
+
+This is the template to use for new SCIPs. Include a short summary of the proposal here.
+
+## Remove this header and add additional detail here
+
+Only the sections above are required. Include additional sections as needed.

--- a/docs/scip/0001-catalog.md
+++ b/docs/scip/0001-catalog.md
@@ -1,0 +1,70 @@
+---
+slug: 1
+title: 1/Catalog
+status: raw
+editor: ots22
+---
+
+# Catalog
+
+A _scivision catalog_ is a collection of metadata about (pre-trained) computer vision models and image datasests.  This document describes the JSON representation of the catalog. 
+
+## Goals
+
+The aim of the scivision catalog is to contain metadata about
+ - _models_ (as described by `2/Models`)
+ - _datasources_ (as described by `3/Datasource`)
+
+so that:
+ - models can be installed and loaded with the scivision io python library
+ - datasources can be loaded similarly, in a convenient format (e.g. a numpy array, xarray Dataset or similar)
+ - models and datasources are discoverable (for example, by the scientific domain from which they originated)
+ - models compatible with a particular data set may be identified (not necessarily a _datasource_)
+ - datasources compatible with a particular image-processing task may be identified (not necessarily a _model_)
+
+## Format
+
+A _scivision catalog_ consists of two JSON data objects, known as the _model catalog_ and the _datasources catalog_.
+
+On disk, these MAY be represented by files `model.json` and `datasources.json`.
+
+### Model catalog
+
+#### Example
+
+```
+  {
+    "name":"Short name for this model"
+    "description":"Longer, optional, description of this model"
+    "tasks":["segmentation"],
+    "url":"https://github.com/alan-turing-institute/my-model",
+    "pkg_url":"git+https://github.com/alan-turing-institute/my-model@master",
+    "format":"image",
+    "pretrained":true,
+    "labels_required":true,
+    "institution":"alan-turing-institute",
+    "tags":[
+      "help-needed", "3D", "cell", "cell-counting", "biology", "biomedical-science" 
+    ]
+  }
+```
+
+### Datasources catalog
+
+#### Example
+
+```
+  {
+    "name":"Short name for this datasource"
+    "description": "Longer, optional, description of this datasource"
+    "tasks":["object-detection", "segmentation"],
+    "domains":["optical-microscopy"],
+    "url":"https://github.com/my_datasource/releases/download/0.3.0/demo.zip",
+    "format":"image",
+    "labels_provided":"yes",
+    "institution":"alan-turing-institute",
+    "tags":[
+      "help-needed", "3D", "cell", "cell-counting", "biology", "biomedical-science" 
+    ]
+  }
+```

--- a/docs/scip/0001-catalog.md
+++ b/docs/scip/0001-catalog.md
@@ -1,11 +1,14 @@
----
-slug: 1
-title: 1/Catalog
-status: raw
-editor: ots22
----
+# 1/Catalog
 
-# Catalog
+## Metadata
+
+Editor:
+  ots22
+
+Status (raw | draft | stable | deprecated | retired):
+  raw
+
+## Description
 
 A _scivision catalog_ is a collection of metadata about (pre-trained) computer vision models and image datasests.  This document describes the JSON representation of the catalog. 
 

--- a/docs/scip_index.rst
+++ b/docs/scip_index.rst
@@ -1,0 +1,43 @@
+SCIPI: The Scivision Improvement Proposal Index
+===============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: About
+
+   about_scips
+
+Template
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   scip/0000-template
+
+
+Status: Raw/draft
+-----------------
+
+.. toctree::
+   :maxdepth: 1
+
+   scip/0001-catalog
+
+
+Status: Stable/deprecated
+-------------------------
+
+(none so far)
+
+.. toctree::
+   :maxdepth: 1
+
+
+Status: Retired
+---------------
+
+(none so far)
+
+.. toctree::
+   :maxdepth: 1

--- a/docs/scip_index.rst
+++ b/docs/scip_index.rst
@@ -1,5 +1,5 @@
 🦘 SCIPI: The Scivision Improvement Proposal Index
-===============================================
+==================================================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/scip_index.rst
+++ b/docs/scip_index.rst
@@ -1,4 +1,4 @@
-SCIPI: The Scivision Improvement Proposal Index
+🦘 SCIPI: The Scivision Improvement Proposal Index
 ===============================================
 
 .. toctree::

--- a/docs/scips.rst
+++ b/docs/scips.rst
@@ -1,0 +1,43 @@
+Scivision Improvement Proposals (SCIPs)
+=======================================
+
+A SCIP, or *Scivision Improvement Proposal*, is a document describing a *standard* for the project: either one that has been accepted and adopted, or that has been suggested.  It is similar to an RFC (Request for Comments) used in other projects, or a PEP (Python Enhancement Proposal) in the Python ecosystem.  A SCIP could describe:
+  - software architecture
+  - an interface or API that the software exposes
+  - a file format
+  - a process or way of working together.
+
+SCIPs that have been adopted (whose *status* is 'stable') complement the project documentation, where relevant SCIPs can be linked and referenced.  Unlike the documentation, they are intended as *normative specifications*, and can be used by implementors to understand the intended behaviour of the system.
+
+When should a SCIP be used?
+---------------------------
+
+Consider making a SCIP if: you would like to propose changes that affect the overall design of the library, introduce or change an interface, and in any situation where **early feedback from the community** on an idea would be helpful.
+
+They are not necessary for every change: For smaller, or self-contained contributions, simply open a pull request to the relevant repository (e.g. `scivision <https://github.com/alan-turing-institute/scivision>`_. This type of change can be made and discussed on the pull request directly.
+
+Who can make a SCIP?
+--------------------
+
+**Any scivision contributor** can propose a SCIP by making a pull request to this repository that adds to the ``docs/scip`` directory, following the steps below. See also the `contributing guide <https://github.com/alan-turing-institute/scivision/blob/main/contributing.md>`_ for advice about contributing to the project generally.
+
+An SCIP has an *editor*, who is normally the proposor, and is responsible for gathering feedback and revising the text before it is adopted, based on feedback in the pull request or any relevant issues and discussions.
+
+The SCIP process
+----------------
+
+We use the `Consensus Oriented Specification System <https://rfc.unprotocols.org/2/>`_ to manage the lifecycle of a SCIP.
+
+In summary, the steps to follow, from proposal to adoption, are listed below. Feel free to ask on the `discussions board <https://github.com/alan-turing-institute/scivision/discussions>`_ if you need any help with any part of this process.
+
+ #. Fork/clone this repository
+ #. Copy the `template SCIP <scip/0000-template.md>`_ to a file in `docs/scip <./docs/scip>`_ (using the next available number for the filename: something like ``0123-short-name.md``)
+ #. Add your GitHub username to the ``editor`` field (or the username of whoever has agreed to be the editor)
+ #. Give it a short, descriptive title, and optionally add any draft text to the relevant sections of the document
+ #. Open a pull request into this repository
+    - Normally this can be merged immediately, even if the text is incomplete or an early draft - ask a maintainer if you do not have sufficient access rights to merge it yourself
+ #. While the status of the SCIP is ``raw`` or ``draft``, the text can be modified in any way, with the process managed by the editor (normally the proposor)
+ #. Consider `discussing <https://github.com/alan-turing-institute/scivision/discussions>`_ the proposal with the community, and requesting feedback or edits from  others as pull requests into this repository
+ #. When it is ready for work to begin on an implementation, change (via pull request) the status to ``draft``
+ #. Once there is broad agreement that it should be adopted (and a working implementation, for code changes), change the status to ``stable``.
+     * Substantial edits should not be made to SCIPs whose status is ``stable``.  Instead, create a new one as a replacement (using this process), perhaps copying and modifying any relevant text, and eventually deprecating/retiring the original.


### PR DESCRIPTION
Some minor changes to the contributing guide. In particular, this PR shortens a few sections and changes focus from _who_ to _what_ we are interested in.  It also adds a mention of SCIPs (and so depends on #225).