### PR TITLE
Add 'force' option to allow_install

### DIFF
--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -47,6 +47,8 @@ def install_package(
     exists = _package_exists(config)
 
     if allow_install == "force" or (allow_install and not exists):
+        # if a package is not already installed, there is little harm
+        # to passing the extra arguments, so these cases are combined
         _install(package, pip_install_args=["--force-reinstall", "--no-cache-dir"])
     elif not exists:
         raise Exception(

--- a/scivision/io/installer.py
+++ b/scivision/io/installer.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 import importlib
 import subprocess
 import sys
+from typing import Literal, Union
 
 
 def _package_exists(config: dict) -> bool:
@@ -25,28 +26,30 @@ def package_from_config(config: dict, branch: str = "main") -> str:
     return f"git+{install_str}@{install_branch}#egg={config['import']}"
 
 
-def _install(package):
+def _install(package, pip_install_args=None):
     """Install a package using pip."""
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+
+    if pip_install_args is None:
+        pip_install_args = []
+
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", *pip_install_args, package]
+    )
 
 
-def _reinstall(package):
-    """Reinstall a package using pip."""
-    subprocess.check_call([sys.executable, "-m", "pip", "install",
-                           "--force-reinstall", "--no-deps", package])
-
-
-def install_package(config: dict, allow_install: bool = False, branch: str = "main"):
+def install_package(
+    config: dict,
+    allow_install: Union[bool, Literal["force"]] = False,
+    branch: str = "main",
+):
     """Install the python package if it doesn't exist."""
     package = package_from_config(config, branch)
-    if _package_exists(config):  # only reinstall if allow_install is True
-        if allow_install:
-            _reinstall(package)
-    else:
-        if allow_install:
-            _install(package)
-        else:
-            raise Exception(
-                "Package does not exist. Try installing it with: \n"
-                f"`!pip install -e {package}`"
-            )
+    exists = _package_exists(config)
+
+    if allow_install == "force" or (allow_install and not exists):
+        _install(package, pip_install_args=["--force-reinstall", "--no-cache-dir"])
+    elif not exists:
+        raise Exception(
+            "Package does not exist. Try installing it with: \n"
+            f"`!pip install -e {package}`"
+        )


### PR DESCRIPTION
This PR is a follow-up to #223.

Uses `pip install --force-reinstall --no-cache-dir` to force reinstallation of a package if `install_package` is called with `allow_install='force'`.

Considered passing these options by default in `_install`, and always calling `install_package`, but this can be unreasonably slow (--no-deps as in #223 is faster, but will sometimes result in dependencies not getting correctly updated).

@edwardchalstrey1 does this approach address the original issue (#221)?

No test for use of this option, since it can add a lot of time (using it with `test_load_pretrained_model_local` takes almost 2 minutes).