### PR TITLE
Add object detection huggingface models

### DIFF
--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -112,7 +112,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":false,
-            "institution":["alan-turing-institute"],
+            "institution":["alan-turing-institute", "huggingface"],
             "tags": ["classification", "2D", "image"]
         },
         {
@@ -123,7 +123,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":false,
-            "institution":["alan-turing-institute"],
+            "institution":["alan-turing-institute", "huggingface"],
             "tags": []
         },
         {
@@ -134,7 +134,7 @@
             "format":"image",
             "pretrained":true,
             "labels_required":false,
-            "institution":["alan-turing-institute"],
+            "institution":["alan-turing-institute", "huggingface"],
             "tags": []
         }
     ]

--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -125,6 +125,17 @@
             "labels_required":false,
             "institution":["alan-turing-institute"],
             "tags": []
+        },
+        {
+            "name":"huggingface-object-detection",
+            "tasks":["object-detection"],
+            "url":"https://github.com/alan-turing-institute/scivision_huggingface_objectdetection",
+            "pkg_url":"git+https://github.com/alan-turing-institute/scivision_huggingface_objectdetection.git@main",
+            "format":"image",
+            "pretrained":true,
+            "labels_required":false,
+            "institution":["alan-turing-institute"],
+            "tags": []
         }
     ]
 }

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="scivision",
-    version="0.2.9",
+    version="0.2.10",
     description="scivision",
     author="The Alan Turing Institute",
     author_email="scivision@turing.ac.uk",


### PR DESCRIPTION
Adds https://github.com/alan-turing-institute/scivision_huggingface_objectdetection to the scivision catalog, which allows loading of a number of [Hugging Face object detection models](https://huggingface.co/models?pipeline_tag=object-detection&sort=downloads)