### PR TITLE
[CAT] Add detectreeRGB model and data

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Code of Conduct
+
+We value the participation of every member of our community and want to ensure that every contributor has an enjoyable and fulfilling experience.
+Accordingly, everyone who participates in the scivision project is expected to show respect and courtesy to other community members at all times.
+
+Scott Hosking, Alan Lowe and Sebastian Anhert, as Co-Is of this project, and all project members, are dedicated to a ***harassment-free experience for everyone***, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. **We do not tolerate harassment by and/or of members of our community in any form**.
+
+We are particularly motivated to support new and/or anxious collaborators, people who are looking to learn and develop their skills, and anyone who has experienced discrimination in the past.
+
+To make clear what is expected, we ask all members of the community to conform to the following Code of Conduct.
+
+* [1 Introduction](#1-introduction)
+* [2 Code of Conduct](#2-code-of-conduct)
+  * [2.1 Expected Behaviour](#21-expected-behaviour)
+  * [2.2 Unacceptable Behaviour](#22-unacceptable-behaviour)
+  * [2.3 Consequences of Unacceptable Behaviour](#23-consequences-of-unacceptable-behaviour)
+  * [2.4 Feedback](#24-feedback)
+* [3 Incident Reporting Guidelines](#3-incident-reporting-guidelines)
+  * [3.1 Contact points](#31-contact-points)
+  * [3.2 Alternate contact points](#32-alternate-contact-points)
+  * [3.3 What to do if someone is in physical danger](#33-what-to-do-if-someone-is-in-physical-danger)
+  * [3.4 Code of Conduct Enforcement](#34-code-of-conduct-enforcement)
+* [4 Enforcement Manual](#4-enforcement-manual)
+  * [4.1 The Code of Conduct Committee](#41-the-code-of-conduct-committee)
+  * [4.2 Urgent Situations: Acting Unilaterally](#42-urgent-situations-acting-unilaterally)
+  * [4.3 Less-Urgent Situations](#43-less-urgent-situations)
+  * [4.4 Resolutions](#44-resolutions)
+  * [4.5 Conflicts of Interest](#45-conflicts-of-interest)
+* [5 Acknowledgements](#5-acknowledgements)
+
+## 1 Introduction
+
+Scivision is an open-source and community-oriented project.
+We value the involvement of everyone in the community.
+We are committed to creating a friendly and respectful place for learning, teaching and contributing.
+All participants in our in-person events and online communications are expected to show respect and courtesy to others at all times.
+
+To make clear what is expected, everyone participating in activities associated with the scivision project is required to conform to this Code of Conduct.
+This Code of Conduct applies to all spaces managed by the scivision project including, but not limited to, in-person focus groups and workshops, and communications online via GitHub.
+
+- Dr Scott Hosking  - is responsible for enforcing the Code of Conduct.
+He can be contacted by emailing [Scott Hosking](mailto:shosking@turing.ac.uk).
+You may contact [Sebastian Anhert](mailto:sanhert@turing.ac.uk), [Aida Mehonic](mailto:amehonic@turing.ac.uk) or [Bea Costa-Gomez](mailto:bcostagomes@turing.ac.uk) if you would prefer not to contact Dr Hosking.
+
+Reports may be reviewed by other members of the core development team, unless there is a conflict of interest, and will be kept confidential.
+
+## 2 Code of Conduct
+
+The scivision team are dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity.
+As such, we do not tolerate behaviour that is disrespectful to our community members or that excludes, intimidates, or causes discomfort to others.
+We do not tolerate discrimination or harassment based on characteristics that include, but are not limited to: gender identity and expression, sexual orientation, disability, physical appearance, body size, citizenship, nationality, ethnic or social origin, pregnancy, familial status, veteran status, genetic information, religion or belief (or lack thereof), membership of a national minority, property, age, education, socio-economic status, technical choices, and experience level.
+
+Everyone who participates in the scivision project activities is required to conform to this Code of Conduct.
+This Code of Conduct applies to all spaces managed by the scivision project including, but not limited to, in person focus groups and workshops, and communications online via GitHub.
+By participating, contributors indicate their acceptance of the procedures by which the scivision project core development team resolves any Code of Conduct incidents, which may include storage and processing of their personal information.
+
+### 2.1 Expected Behaviour
+
+We are confident that our community members will together build a supportive and collaborative atmosphere at our events and during online communications.
+The following bullet points set out explicitly what we hope you will consider to be appropriate community guidelines:
+
+* **Be respectful of different viewpoints and experiences**. Do not engage in homophobic, racist, transphobic, ageist, ableist, sexist, or otherwise exclusionary behaviour.
+* **Use welcoming and inclusive language**. Exclusionary comments or jokes, threats or violent language are not acceptable. Do not address others in an angry, intimidating, or demeaning manner. Be considerate of the ways the words you choose may impact others. Be patient and respectful of the fact that English is a second (or third or fourth!) language for some participants.
+* **Do not harass people**. Harassment includes unwanted physical contact, sexual attention, or repeated social contact. Know that consent is explicit, conscious and continuous—not implied. If you are unsure whether your behaviour towards another person is welcome, ask them. If someone tells you to stop, do so.
+* **Respect the privacy and safety of others**. Do not take photographs of others without their permission. Do not share other participant’s personal experiences without their express permission. Note that posting (or threatening to post) personally identifying information of others without their consent ("doxing") is a form of harassment.
+* **Be considerate of others’ participation**. Everyone should have an opportunity to be heard. In update sessions, please keep comments succinct so as to allow maximum engagement by all participants. Do not interrupt others on the basis of disagreement; hold such comments until they have finished speaking.
+* **Don’t be a bystander**. If you see something inappropriate happening, speak up. If you don't feel comfortable intervening but feel someone should, please feel free to ask a member of the Code of Conduct response team for support.
+* As an overriding general rule, please **be intentional in your actions and humble in your mistakes**.
+
+All interactions should be professional regardless of platform: either online or in-person.
+See [this explanation of the four social rules](https://www.recurse.com/manual#sub-sec-social-rules) - no feigning surprise, no well-actually's, no back-seat driving, no subtle -isms - for further recommendations for inclusive behaviours.
+
+### 2.2 Unacceptable Behaviour
+
+Examples of unacceptable behaviour by scivision community members at any project event or platform include:
+
+* written or verbal comments which have the effect of excluding people on the basis of membership of any specific group
+* causing someone to fear for their safety, such as through stalking, following, or intimidation
+* violent threats or language directed against another person
+* the display of sexual or violent images
+* unwelcome sexual attention
+* nonconsensual or unwelcome physical contact
+* sustained disruption of talks, events or communications
+* insults or put downs
+* sexist, racist, homophobic, transphobic, ableist, or exclusionary jokes
+* excessive swearing
+* incitement to violence, suicide, or self-harm
+* continuing to initiate interaction (including photography or recording) with someone after being asked to stop
+* publication of private communication without consent
+
+### 2.3 Consequences of Unacceptable Behaviour
+
+Participants who are asked to stop any inappropriate behaviour are expected to comply immediately.
+This applies to all scivision community events and platforms, either online or in-person.
+If a participant engages in behaviour that violates this Code of Conduct, any member of the core development team may warn the offender, ask them to leave the event or platform (without refund), or impose any other appropriate sanctions (see the [enforcement manual](#4-enforcement-manual) for details).
+
+### 2.4 Feedback
+
+This Code of Conduct is not intended as a static set of rules by which everyone must abide.
+Rather, you are invited to make suggestions for updates or clarifications by contacting [Dr Scott Hosking](mailto:shosking@turing.ac.uk) or by making a pull request to this document on GitHub.
+
+## 3 Incident Reporting Guidelines
+
+### 3.1 Contact points
+
+If you feel able to, please contact [Dr Scott Hosking ](mailto:@turing.ac.uk).
+
+### 3.2 Alternate contact points
+
+If you do not feel comfortable contacting , please report an incident to by email at [Sebastian Anhert](mailto:anhert@turing.ac.uk).
+
+Alternatively, if you would like to contact someone outside of the core development team, please contact [Aida Mehonic](mailto:amehonic@turing.ac.uk).
+
+### 3.3 What to do if someone is in physical danger
+
+If you believe someone is in physical danger, please contact the appropriate emergency responders.
+
+### 3.4 Code of Conduct Enforcement
+
+A detailed enforcement policy is available in the Enforcement Manual below.
+
+## 4 Enforcement Manual
+
+This is the enforcement manual followed by the scivision project research team.
+It's used when we respond to an issue to make sure we're consistent and fair.
+Enforcement of the Code of Conduct should be respectful and not include any harassing behaviours.

--- a/scivision/catalog/data/datasources.json
+++ b/scivision/catalog/data/datasources.json
@@ -122,6 +122,29 @@
             "ecology",
             "environmental-science"
          ]
+      },
+      {
+         "name":"data-006",
+         "description":"Sample dataset of drone RGB imagery required to demonstrate the detectreeRGB authored by Hickman et al. (2021)",
+         "tasks":[
+            "object-detection", "segmentation"
+         ],
+         "domains":[
+            "computer-vision", "earth-observation", "ecology"
+         ],
+         "url":"https://github.com/acocac/detectreeRGB-treecrown-scivision",
+         "format":"image",
+         "labels_provided":false,
+         "institution":["Cambridge University"],
+         "tags":[
+            "2D",
+            "drone",
+            "satellite",
+            "aerial",
+            "remote-sensing",
+            "ecology",
+            "environmental-science"
+         ]
       }
    ]
 }

--- a/scivision/catalog/data/datasources.json
+++ b/scivision/catalog/data/datasources.json
@@ -132,7 +132,7 @@
          "domains":[
             "computer-vision", "earth-observation", "ecology"
          ],
-         "url":"https://github.com/acocac/detectreeRGB-treecrown-scivision",
+         "url":"https://github.com/shmh40/detectreeRGB-treecrown-scivision",
          "format":"image",
          "labels_provided":false,
          "institution":["Cambridge University"],

--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -136,6 +136,17 @@
             "labels_required":false,
             "institution":["alan-turing-institute", "huggingface"],
             "tags": []
+        },
+        {
+            "name":"detectreeRGB-forest",
+            "tasks":["object-detection","segmentation"],
+            "url":"https://github.com/acocac/detectreeRGB-treecrown-scivision",
+            "pkg_url":"git+https://github.com/acocac/detectreeRGB-treecrown-scivision.git@main",
+            "format":"image",
+            "pretrained":true,
+            "labels_required":false,
+            "institution":["cambridge-university"],
+            "tags": ["object-detection","segmentation", "2D", "image"]
         }
     ]
 }

--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -140,8 +140,8 @@
         {
             "name":"detectreeRGB-forest",
             "tasks":["object-detection","segmentation"],
-            "url":"https://github.com/acocac/detectreeRGB-treecrown-scivision",
-            "pkg_url":"git+https://github.com/acocac/detectreeRGB-treecrown-scivision.git@main",
+            "url":"https://github.com/shmh40/detectreeRGB-treecrown-scivision",
+            "pkg_url":"git+https://github.com/shmh40/detectreeRGB-treecrown-scivision.git@main",
             "format":"image",
             "pretrained":true,
             "labels_required":false,

--- a/scivision/catalog/data/models.json
+++ b/scivision/catalog/data/models.json
@@ -146,7 +146,7 @@
             "pretrained":true,
             "labels_required":false,
             "institution":["cambridge-university"],
-            "tags": ["object-detection","segmentation", "2D", "image"]
+            "tags": ["2D", "satellite", "remote-sensing", "ecology", "environmental-science"]
         }
     ]
 }


### PR DESCRIPTION
This PR refers to add the [detectreeRGB model plugin](https://github.com/acocac/detectreeRGB-treecrown-scivision) (temporalily hosted in my personal GH repo) to predict the location and extent of tree crowns from a top-down RGB image, captured by drone, aircraft or satellite

Some observations:

The model repository will be transfered to the model developer, @shmh40
The model works with python=3.8