### PR TITLE
Update supported scivision version for python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Scivision development happens in the [Scivision GitHub repo](https://github.com/
 | ^3.7 | <0.4 |
 | ^3.8 | * (any) |
 | ^3.9 | * (any) |
-| ^3.10 | * (any) |
+| ^3.10 | >=0.3 |
 | >=3.11 | >=0.3, untested, but intending to support (bug reports welcome) |
 
 Scivision is currently working towards supporting Python >=3.11.


### PR DESCRIPTION
Changing to >=0.3, since we haven't tested with the older versions and which were known not to work at some point.