### PR TITLE
Change package.json homepage to serve from scivision.org

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "homepage": "scivision/",
+  "homepage": "/",
   "dependencies": {
     "@rjsf/bootstrap-4": "^4.2.0",
     "@rjsf/core": "^4.2.0",


### PR DESCRIPTION
- Serving from `alan-turing-institute.github.io/scivision`, npm homepage in package.json should be '/scivision'
- Serving from `scivision.org/`, it should be '/'
- This PR switches to the latter config