### PR TITLE
[Experiment] Python code display in front end

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -388,6 +388,15 @@ function ModelDefinitionListFragment({data}) {
                 <dd className="col-sm-9">
                     <div><code>pip install {data.pkg_url}</code></div>
                 </dd>
+                <dt className="col-sm-3"><a href="https://scivision.readthedocs.io/en/latest/api.html">Scivision Python Code</a>:</dt>
+                <dd className="col-sm-9">
+                    <div>
+                      <p><code>import scivision</code></p>
+                      <p><code>model = scivision.load_pretrained_model({data.url})</code></p>
+                      <p><code>data = scivision.load_dataset({'<datasource url>'})</code></p>
+                      <p><code>model.predict(data)</code></p>
+                    </div>
+                </dd>
             </>);
 }
 


### PR DESCRIPTION
This PR isn't intending to be merged in its current state, but explores some of the options from #347

I've tried to think about how we might auto-generate the ~"5 lines of scivision code" needed to load a datasource, a model and generate a prediction. The difficulty I realise it that that isn't actually how scivision works currently, there is no simple "5 lines" approach. We could come closer to that after #480 is resolved, especially if this results in no additional steps between `load_dataset` and `model.predict`. A model page could then have code displayed like so (see the code changes in this PR):

<img width="986" alt="Screenshot 2023-01-31 at 16 07 46" src="https://user-images.githubusercontent.com/5486164/215815186-d818232f-ae84-4d40-8c1f-fa5b91cca027.png">

Having said this, it might be preferable to not have any code on the model pages and instead save this specifically for the proposed matching page in #347 
