### PR TITLE
Bug fix: Mobile nav collapse 

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -87,20 +87,20 @@ function App() {
                     </Navbar>
 
                     {/* Navigation bar */}
-                    <Navbar collapseOnSelect expand="md" className="px-0" >
+                    <Navbar collapseOnSelect expand="md" className="px-0">
                         <Container fluid className="p-0">
                             <Navbar.Toggle aria-controls="responsive-navbar-nav" className="ml-auto" />
                             <Navbar.Collapse id="responsive-navbar-nav">
                                 <Nav className="me-auto">
-                                    <Nav.Link to="" as={NavLink}>
+                                    <Nav.Link to="" as={NavLink} eventKey="home">
                                         Home
                                     </Nav.Link>
 
-                                    <Nav.Link to="about" as={NavLink}>
+                                    <Nav.Link to="about" as={NavLink} eventKey="about">
                                         About
                                     </Nav.Link>
 
-                                    <Nav.Link to="scivisionpy" as={NavLink}>
+                                    <Nav.Link to="scivisionpy" as={NavLink} eventKey="scivisionpy">
                                         Scivision.Py
                                     </Nav.Link>
 
@@ -115,7 +115,7 @@ function App() {
                                             location_root === "model-table"
                                             || location_root === "new-model"
                                             || location_root === "model"
-                                        }>
+                                        } eventKey="model">
                                         Models
                                     </Nav.Link>
 
@@ -124,7 +124,7 @@ function App() {
                                             location_root === "datasource-table"
                                             || location_root === "new-datasource"
                                             || location_root === "datasource"
-                                        }>
+                                        } eventKey="datasource">
                                         Data
                                     </Nav.Link>
                                     <Nav.Link to="project-grid" as={NavLink}
@@ -132,11 +132,11 @@ function App() {
                                             location_root === "project-table"
                                             || location_root === "new-project"
                                             || location_root === "project"
-                                        }>
+                                        } eventKey="project">
                                         Projects
                                     </Nav.Link>
 
-                                    <Nav.Link to="community" as={NavLink}>
+                                    <Nav.Link to="community" as={NavLink} eventKey="community">
                                         Community
                                     </Nav.Link>
 


### PR DESCRIPTION
It seems I didn't check the mobile nav properly in my last PR. 😬

When a nav item is clicked in the mobile nav, it should collapse the Navbar, bring it back to its closed position. 
But react-bootstrap being made for SPA, `collapseOnSelect` attribute on the Navbar does not work well with react-router. 

The discussions in the react-boostrap recommends installing the [react-router-boostrap]( https://github.com/react-bootstrap/react-router-bootstrap) package, which requires wrapping all the router links(including the Nav links) with a new `<LinkContainer>` bootstrap element for all router links to work perfectly. 

This PR fixes that with a workaround as I don't think currently there is a need to use `<LinkContainer>` for all the router links as everything else seems to be working fine.

But if you think its better to use that package instead, I will update this PR with the necessary changes.