### PR TITLE
Windows fixes

### DIFF
--- a/.github/workflows/scivision.yml
+++ b/.github/workflows/scivision.yml
@@ -3,11 +3,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os: ['ubuntu-latest', 'windows-latest']
         python-version: ['3.8', '3.9', '3.10']
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -34,3 +35,18 @@ jobs:
         pip install -e .
         pip install pytest
         pytest
+        
+  all-builds-passing:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Check all build jobs succeeded
+        run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+    

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import find_packages, setup
 # read the contents of your README file
 from pathlib import Path
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 requirements = []
-with open("requirements.txt") as f:
+with open("requirements.txt", encoding="utf-8") as f:
     for line in f:
         stripped = line.split("#")[0].strip()
         if len(stripped) > 0:


### PR DESCRIPTION
This PR includes:
- #588
- #589

It fixes #587

Note: the previous branch protection rules, checking that the build passed, depended on the names of the checks from the build matrix.  #588 changes these (it now includes the OS), but introduces a single check `all-builds-passing`.  The branch protection rule for main has been updated, but open PRs will need to include this change to work.