### PR TITLE
Fix image location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="imgs/logo_name.png?raw=true)" width="600"/>
+<img src="imgs/logo_name.png" width="600"/>
 </p>
 
 # A toolkit for scientific image analysis

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ entry_points = {
 
 setup(
     name="scivision",
-    version="0.6.0",
+    version="0.6.1",
     description="scivision",
     author="The Alan Turing Institute",
     author_email="scivision@turing.ac.uk",


### PR DESCRIPTION
Change Scivision banner image source from `imgs/logo_name.png?raw=true)` (which breaks in PyPI) to `imgs/logo_name.png` for release 0.6.1 to attempt to fix this.
