### PR TITLE
Use absolute URL for Scivision logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="imgs/logo_name.png" width="600"/>
+<img src="https://raw.githubusercontent.com/alan-turing-institute/scivision/main/imgs/logo_name.png" width="600"/>
 </p>
 
 # A toolkit for scientific image analysis

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ entry_points = {
 
 setup(
     name="scivision",
-    version="0.6.1",
+    version="0.6.2",
     description="scivision",
     author="The Alan Turing Institute",
     author_email="scivision@turing.ac.uk",


### PR DESCRIPTION
Relase 0.6.2: Attempt to fix broken image on PyPI (#607 didn't work)