### PR TITLE
Bump pandas version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib~=3.6
 numpy~=1.23
 scipy~=1.9
-pandas~=1.5
+pandas>=1.5,<3
 fsspec>=2022.11
 pyyaml~=6.0
 requests~=2.28


### PR DESCRIPTION
This loosens the requirement on the pandas version (2.0 was released in April).

None of the [breaking changes](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#backwards-incompatible-api-changes) from v1.0 affects scivision.

Closes #593 