### PR TITLE
Add copy to clipboard in the markdown rendered content

### DIFF
--- a/frontend/src/components/SingleView.tsx
+++ b/frontend/src/components/SingleView.tsx
@@ -114,6 +114,7 @@ load_pretrained_model("${url}")`}
                         </dt>
                         <CopyToClipboard
                           codeText={`pip install ${pkg_url}`}
+                          lang="language-bash"
                         />
                     </div>
                     {scivision_code}

--- a/frontend/src/pages/ScivisionPy/content.md
+++ b/frontend/src/pages/ScivisionPy/content.md
@@ -13,7 +13,7 @@ The full documentation is [here](https://scivision.readthedocs.io/en/latest/), a
 From a terminal, run
 
 ```bash
-$ pip install scivision
+pip install scivision
 ```
 
 ### Load a model

--- a/frontend/src/utils/ParseMarkdown.tsx
+++ b/frontend/src/utils/ParseMarkdown.tsx
@@ -4,6 +4,21 @@ import ReactPlayer from 'react-player/youtube'
 import { PageTitle } from '@/components/Typography'
 import Markdown from 'markdown-to-jsx'
 import matter from 'gray-matter'
+import CopyToClipboard from '@/components/CopyToClipboard'
+
+type CodeAdapterProps = {
+    children?: string
+    className?: string
+}
+
+const CodeAdapter = ({ children, className, ...rest }: CodeAdapterProps) => {
+    const codeText = Array.isArray(children)
+        ? children.join('')
+        : String(children ?? '')
+    const lang = className || 'language-text'
+
+    return <CopyToClipboard codeText={codeText} lang={lang} {...rest} />
+}
 
 const ParseMarkdown = (props: { markdown: string }) => {
     const parsedMarkdown = matter(props.markdown)
@@ -17,6 +32,9 @@ const ParseMarkdown = (props: { markdown: string }) => {
                         overrides: {
                             Link,
                             ReactPlayer,
+                            code: {
+                                component: CodeAdapter,
+                            },
                         },
                     }}
                 >


### PR DESCRIPTION
## Summary 

As discussed in #728 

Added the copy to clipboard functionality to the markdown to jsx rendered content by adding an override to the component. 
The override uses the same `CopyToClipboard` component to render the copy button.

Added a minor fix to show the proper language highlighting for bash commands for the model single view component.

Thank you
 